### PR TITLE
Fixed assigning HAVE_ENOUGH_DATA to media player

### DIFF
--- a/Source/WebCore/Modules/mediasource/MediaSource.cpp
+++ b/Source/WebCore/Modules/mediasource/MediaSource.cpp
@@ -255,7 +255,7 @@ void MediaSource::monitorSourceBuffers()
     // https://dvcs.w3.org/hg/html-media/raw-file/default/media-source/media-source.html#buffer-monitoring
 
     // Note, the behavior if activeSourceBuffers is empty is undefined.
-    if (!m_activeSourceBuffers) {
+    if (!m_activeSourceBuffers || m_activeSourceBuffers->length() == 0) {
         m_private->setReadyState(MediaPlayer::HaveNothing);
         return;
     }


### PR DESCRIPTION
Fixed MediaSource::monitorSourceBuffers() to prevent assigning HAVE_ENOUGH_DATA to media player
which led to send loadeddata event before initialization segment received,
and no valid duration, seekable and other attributes returned.
