### PR TITLE
Small fix in Extensions3DCache.cpp prevents crashes in WPEWebProcess

### DIFF
--- a/Source/WebCore/platform/graphics/texmap/Extensions3DCache.cpp
+++ b/Source/WebCore/platform/graphics/texmap/Extensions3DCache.cpp
@@ -47,7 +47,11 @@ Extensions3DCache::Extensions3DCache()
     GLContext* previousActiveContext = GLContext::getCurrent();
 
     if (!previousActiveContext)
+    {
+        if (!GLContext::sharingContext())
+            return;
         GLContext::sharingContext()->makeContextCurrent();
+    }
 
     RefPtr<GraphicsContext3D> context3D = GraphicsContext3D::createForCurrentGLContext();
     m_GL_EXT_unpack_subimage = context3D->getExtensions()->supports("GL_EXT_unpack_subimage");


### PR DESCRIPTION
[backtrace.txt](https://github.com/Metrological/WebKitForWayland/files/638750/backtrace.txt)
