### PR TITLE
[GStreamer] further cleanups after GL/fakesink changes

### DIFF
--- a/Source/WebCore/platform/graphics/gstreamer/MediaPlayerPrivateGStreamerBase.cpp
+++ b/Source/WebCore/platform/graphics/gstreamer/MediaPlayerPrivateGStreamerBase.cpp
@@ -92,21 +92,6 @@
 #endif
 
 #define WL_EGL_PLATFORM
-
-#if USE(OPENGL_ES_2)
-#if GST_CHECK_VERSION(1, 8, 1)
-#if !USE(HOLE_PUNCH_GSTREAMER)
-#if USE(GSTREAMER_GL)
-#define GST_USE_UNSTABLE_API
-#include <gst/gl/egl/gstglmemoryegl.h>
-#undef GST_USE_UNSTABLE_API
-#endif
-#endif
-#endif
-#include <GLES2/gl2.h>
-#include <GLES2/gl2ext.h>
-#endif
-
 #include <EGL/egl.h>
 
 #if ENABLE(LEGACY_ENCRYPTED_MEDIA_V1)


### PR DESCRIPTION
Commits bf1e59edfc89eda8ffb75cc96fb68fdba5c1afbf and
a0ec49e9a31a7666473644281c1240e278963ae0 removed some code, but not
the matching headers.

Build without GSTREAMER_GL was broken.