### PR TITLE
Fixed bug with zero size.

### DIFF
--- a/Source/ThirdParty/WPE-platform/src/westeros/WesterosViewbackendOutput.cpp
+++ b/Source/ThirdParty/WPE-platform/src/westeros/WesterosViewbackendOutput.cpp
@@ -66,8 +66,8 @@ void WesterosViewbackendOutput::handleScaleCallback( void *UserData, int32_t sca
 WesterosViewbackendOutput::WesterosViewbackendOutput(struct wpe_view_backend* backend)
  : m_compositor(nullptr)
  , m_viewbackend(backend)
- , m_width(0)
- , m_height(0)
+ , m_width(800)
+ , m_height(600)
  , m_modeDataArray(g_ptr_array_sized_new(4))
 {
 }


### PR DESCRIPTION
Which caused a problem with resizing the window.
If 0:0 is passed to wl_egl_window_create
not possible to do wl_egl_window_resize
Seems due to eglCreateWindowSurface returns null if size is 0:0