### PR TITLE
XKB Key mapping for media play/pause

### DIFF
--- a/Source/ThirdParty/WPE-platform/src/input/XKB/input-libxkbcommon.cpp
+++ b/Source/ThirdParty/WPE-platform/src/input/XKB/input-libxkbcommon.cpp
@@ -287,8 +287,9 @@ struct wpe_input_key_mapper_interface libxkbcommon_input_key_mapper_interface = 
                 // VK_MENU (12) ALT key
 
             case XKB_KEY_Pause:
-            case XKB_KEY_XF86AudioPause:
                 return VK_PAUSE; // (13) PAUSE key
+            case XKB_KEY_XF86AudioPause:
+                return VK_MEDIA_PLAY_PAUSE; // (B3) Windows 2000/XP: Play/Pause Media key
             case XKB_KEY_Caps_Lock:
                 return VK_CAPITAL; // (14) CAPS LOCK key
             case XKB_KEY_Kana_Lock:
@@ -569,7 +570,7 @@ struct wpe_input_key_mapper_interface libxkbcommon_input_key_mapper_interface = 
                 // VK_EXSEL (F8) ExSel key
                 // VK_EREOF (F9) Erase EOF key
             case XKB_KEY_XF86AudioPlay:
-                return VK_PLAY; // VK_PLAY (FA) Play key
+                return VK_MEDIA_PLAY_PAUSE; // (B3) Windows 2000/XP: Play/Pause Media key
                 // VK_ZOOM (FB) Zoom key
                 // VK_NONAME (FC) Reserved for future use
                 // VK_PA1 (FD) PA1 key


### PR DESCRIPTION
Correcting XKB key mapping for XKB_KEY_XF86AudioPlay and XKB_KEY_XF86AudioPause to use
VK_MEDIA_PLAY_PAUSE