### PR TITLE
Enable antialiasing on accelerated canvas when msaa is available on cairo

### DIFF
--- a/Source/WebCore/platform/graphics/cairo/ImageBufferCairo.cpp
+++ b/Source/WebCore/platform/graphics/cairo/ImageBufferCairo.cpp
@@ -34,6 +34,7 @@
 #include "BitmapImage.h"
 #include "CairoUtilities.h"
 #include "Color.h"
+#include "Extensions3DCache.h"
 #include "GraphicsContext.h"
 #include "MIMETypeRegistry.h"
 #include "NotImplemented.h"
@@ -68,6 +69,16 @@
 using namespace std;
 
 namespace WebCore {
+
+bool cairoIsUsingMSAA()
+{
+    // Cairo will use MSAA if the extensions GL_OES_packed_depth_stencil and GL_EXT_multisampled_render_to_texture
+    // are available, and when it's told to use the msaa compositor through the CAIRO_GL_COMPOSITOR env variable.
+    const char *env = getenv ("CAIRO_GL_COMPOSITOR");
+    bool usingMSAACompositor = env && strcmp(env, "msaa") == 0;
+
+    return usingMSAACompositor && Extensions3DCache::singleton().GL_OES_packed_depth_stencil() && Extensions3DCache::singleton().GL_EXT_multisampled_render_to_texture();
+}
 
 ImageBufferData::ImageBufferData(const IntSize& size, RenderingMode renderingMode)
     : m_platformContext(0)
@@ -254,7 +265,9 @@ ImageBuffer::ImageBuffer(const FloatSize& size, float resolutionScale, ColorSpac
 
     RefPtr<cairo_t> cr = adoptRef(cairo_create(m_data.m_surface.get()));
     m_data.m_platformContext.setCr(cr.get());
-    cairo_set_antialias(cr.get(), CAIRO_ANTIALIAS_NONE);
+    // Disable antialiasing if using the GL backend but cairo is not using MSAA.
+    if ((m_data.m_renderingMode == Accelerated) && !cairoIsUsingMSAA())
+        cairo_set_antialias(cr.get(), CAIRO_ANTIALIAS_NONE);
     m_data.m_context = std::make_unique<GraphicsContext>(&m_data.m_platformContext);
     success = true;
 }

--- a/Source/WebCore/platform/graphics/texmap/Extensions3DCache.cpp
+++ b/Source/WebCore/platform/graphics/texmap/Extensions3DCache.cpp
@@ -51,6 +51,8 @@ Extensions3DCache::Extensions3DCache()
 
     RefPtr<GraphicsContext3D> context3D = GraphicsContext3D::createForCurrentGLContext();
     m_GL_EXT_unpack_subimage = context3D->getExtensions()->supports("GL_EXT_unpack_subimage");
+    m_GL_OES_packed_depth_stencil = context3D->getExtensions()->supports("GL_OES_packed_depth_stencil");
+    m_GL_EXT_multisampled_render_to_texture = context3D->getExtensions()->supports("GL_EXT_multisampled_render_to_texture");
     context3D.release();
 
     if (previousActiveContext)

--- a/Source/WebCore/platform/graphics/texmap/Extensions3DCache.h
+++ b/Source/WebCore/platform/graphics/texmap/Extensions3DCache.h
@@ -38,12 +38,16 @@ public:
     static const Extensions3DCache& singleton();
 
     bool GL_EXT_unpack_subimage() const { return m_GL_EXT_unpack_subimage; }
+    bool GL_OES_packed_depth_stencil() const { return m_GL_OES_packed_depth_stencil; }
+    bool GL_EXT_multisampled_render_to_texture() const { return m_GL_EXT_multisampled_render_to_texture; }
 
 private:
     friend class LazyNeverDestroyed<Extensions3DCache>;
     Extensions3DCache();
 
     bool m_GL_EXT_unpack_subimage;
+    bool m_GL_OES_packed_depth_stencil;
+    bool m_GL_EXT_multisampled_render_to_texture;
 };
 
 } // namespace WebCore


### PR DESCRIPTION
This should enable antialiasing on accelerated canvas when cairo is able to use MSAA.
In order to make this work this env variable needs to be set:
CAIRO_GL_COMPOSITOR=msaa
or cairo won't use the msaa compositor.