### PR TITLE
Differentiate the explicit pause request from the pause performed for buffering purpose. 

### DIFF
--- a/Source/WebCore/platform/graphics/gstreamer/MediaPlayerPrivateGStreamer.cpp
+++ b/Source/WebCore/platform/graphics/gstreamer/MediaPlayerPrivateGStreamer.cpp
@@ -509,9 +509,10 @@ void MediaPlayerPrivateGStreamer::pause()
     if (currentState < GST_STATE_PAUSED && pendingState <= GST_STATE_PAUSED)
         return;
 
-    if (changePipelineState(GST_STATE_PAUSED))
+    if (changePipelineState(GST_STATE_PAUSED)) {
+        m_paused = true;
         GST_INFO("Pause");
-    else
+    } else
         loadingFailed(MediaPlayer::Empty);
 }
 


### PR DESCRIPTION
Differentiate the explicit pause request from the pause performed for buffering purpose.
 
Currently explicit pause requests are being overridden in case of live-streams.
The explicit pause in this case is being treated as a pause performed for buffering purpose and hence forced to GST_STATE_PLAYING state, whenever buffering is complete. 
Since the buffering states can keep varying in case of live-streams, we need to differentiate an explicit pause request and prevent forced playing in this case.
