### PR TITLE
Fix for the "ThreadedCompositor crash on exit" problem

### DIFF
--- a/Source/WebKit2/WebProcess/WebPage/wpe/DrawingAreaWPE.cpp
+++ b/Source/WebKit2/WebProcess/WebPage/wpe/DrawingAreaWPE.cpp
@@ -25,6 +25,8 @@ DrawingAreaWPE::DrawingAreaWPE(WebPage& webPage, const WebPageCreationParameters
 
 DrawingAreaWPE::~DrawingAreaWPE()
 {
+    if (m_layerTreeHost)
+        m_layerTreeHost->invalidate();
 }
 
 void DrawingAreaWPE::layerHostDidFlushLayers()


### PR DESCRIPTION
We've noticed repeated crashes that seem to happen upon exit (__run_exit_handlers is running).
Looks like the problem is caused by accessing resources (here accessing a string by getLocation) that was already freed by another tread. In other words CompositingRunLoop keep running while necessary resources are already destroyed.
getLocation is called by ThreadedCompositor through the CompositingRunLoop. Seems like DisplayRefreshMonitor keep trigger updates that lead to one shot fires by CompositingRunLoop.
Adding invalidate to the destructor should stop CompositingRunLoop updates as well as invalidate the DisplayRefreshMonitor

**An excerpt from the crash stacktrace:**
**Crash thread #10**  
Frame	Signature	Module	Source
#0	WebCore::TextureMapperShaderProgram::getLocation	libWPEWebKit.so.0.0.20160901	/mnt/jenkins/workspace/ARRISXG1V3-Yocto-Build/build-arrisxg1v3/tmp/work/mips32el-rdk-linux/wpe-webkit/0.1+gitAUTOINC+e2fa58c746-r0/git/Source/WTF/wtf/text/StringImpl.h:532 (0x0)
#1	WebCore::TextureMapperGL::drawSolidColor	libWPEWebKit.so.0.0.20160901	/mnt/jenkins/workspace/ARRISXG1V3-Yocto-Build/build-arrisxg1v3/tmp/work/mips32el-rdk-linux/wpe-webkit/0.1+gitAUTOINC+e2fa58c746-r0/git/Source/WebCore/platform/graphics/texmap/TextureMapperShaderProgram.h:75 (0x14)
#2	WebKit::CoordinatedGraphicsScene::paintToCurrentGLContext	libWPEWebKit.so.0.0.20160901	/mnt/jenkins/workspace/ARRISXG1V3-Yocto-Build/build-arrisxg1v3/tmp/work/mips32el-rdk-linux/wpe-webkit/0.1+gitAUTOINC+e2fa58c746-r0/git/Source/WebKit2/Shared/CoordinatedGraphics/CoordinatedGraphicsScene.cpp:111 (0x0)
#3	WebKit::ThreadedCompositor::renderLayerTree	libWPEWebKit.so.0.0.20160901	/mnt/jenkins/workspace/ARRISXG1V3-Yocto-Build/build-arrisxg1v3/tmp/work/mips32el-rdk-linux/wpe-webkit/0.1+gitAUTOINC+e2fa58c746-r0/git/Source/WebKit2/Shared/CoordinatedGraphics/threadedcompositor/ThreadedCompositor.cpp:277 (0x4)
#4	std::_Function_handler<void(), WebKit::ThreadedCompositor::ThreadedCompositor(WebKit::ThreadedCompositor::Client*, WebKit::WebPage&, uint64_t)::<lambda()> >::_M_invoke	libWPEWebKit.so.0.0.20160901	/mnt/jenkins/workspace/ARRISXG1V3-Yocto-Build/build-arrisxg1v3/tmp/work/mips32el-rdk-linux/wpe-webkit/0.1+gitAUTOINC+e2fa58c746-r0/git/Source/WebKit2/Shared/CoordinatedGraphics/threadedcompositor/ThreadedCompositor.cpp:63 (0x0)
#5	WebKit::CompositingRunLoop::updateTimerFired	libWPEWebKit.so.0.0.20160901	/mnt/jenkins/workspace/ARRISXG1V3-Yocto-Build/build-arrisxg1v3/tmp/sysroots/arrisxg1v3/usr/include/c++/functional:2439 (0x4)
#6	WTF::RunLoop::Timer<WebKit::CompositingRunLoop>::fired	libWPEWebKit.so.0.0.20160901	/mnt/jenkins/workspace/ARRISXG1V3-Yocto-Build/build-arrisxg1v3/tmp/work/mips32el-rdk-linux/wpe-webkit/0.1+gitAUTOINC+e2fa58c746-r0/git/Source/WTF/wtf/RunLoop.h:144 (0x8)
#7	libWPEWebKit.so.0.0.20160901@0x24c9248	libWPEWebKit.so.0.0.20160901	
#8	WTF::<lambda(GSource*, GSourceFunc, gpointer)>::_FUN	libWPEWebKit.so.0.0.20160901	/mnt/jenkins/workspace/ARRISXG1V3-Yocto-Build/build-arrisxg1v3/tmp/work/mips32el-rdk-linux/wpe-webkit/0.1+gitAUTOINC+e2fa58c746-r0/git/Source/WTF/wtf/glib/RunLoopGLib.cpp:44 (0x0)
#9	libglib-2.0.so.0.4800.1@0x5da3c	libglib-2.0.so.0.4800.1	
#10	libpthread-2.19.so@0x2c2ec	libpthread-2.19.so	
#11	libglib-2.0.so.0.4800.1@0x5e54c	libglib-2.0.so.0.4800.1	
#12	WTF::RunLoop::run	libWPEWebKit.so.0.0.20160901	/mnt/jenkins/workspace/ARRISXG1V3-Yocto-Build/build-arrisxg1v3/tmp/work/mips32el-rdk-linux/wpe-webkit/0.1+gitAUTOINC+e2fa58c746-r0/git/Source/WTF/wtf/glib/RunLoopGLib.cpp:97 (0x4)
#13	std::_Function_handler<void(), WTF::WorkQueue::platformInitialize(char const*, WTF::WorkQueue::Type, WTF::WorkQueue::QOS)::<lambda()> >::_M_invoke	libWPEWebKit.so.0.0.20160901	/mnt/jenkins/workspace/ARRISXG1V3-Yocto-Build/build-arrisxg1v3/tmp/work/mips32el-rdk-linux/wpe-webkit/0.1+gitAUTOINC+e2fa58c746-r0/git/Source/WTF/wtf/generic/WorkQueueGeneric.cpp:58 (0x4)
#14	WTF::threadEntryPoint	libWPEWebKit.so.0.0.20160901	/mnt/jenkins/workspace/ARRISXG1V3-Yocto-Build/build-arrisxg1v3/tmp/sysroots/arrisxg1v3/usr/include/c++/functional:2439 (0x8)
#15	WTF::wtfThreadEntryPoint	libWPEWebKit.so.0.0.20160901	/mnt/jenkins/workspace/ARRISXG1V3-Yocto-Build/build-arrisxg1v3/tmp/work/mips32el-rdk-linux/wpe-webkit/0.1+gitAUTOINC+e2fa58c746-r0/git/Source/WTF/wtf/ThreadingPthreads.cpp:164 (0x0)
#16	libpthread-2.19.so@0x6cd4	libpthread-2.19.so	
**Thread #0**
Frame	Signature	Module	Source
#0	kernel::UTF8String::~UTF8String	libauditude.so.0.0.0	/mnt/jenkins/workspace/ARRISXG1V3-Yocto-Build/build-arrisxg1v3/tmp/work/mips32el-rdk-linux/ave-auditude/1.99+git67a275ad35-r0/git/modules/auditude/./../kernel/include/kernel/String.h:1203 (0x0)
#1	__run_exit_handlers	libc-2.19.so	/mnt/jenkins/workspace/ARRISXG1V3-Yocto-Build/build-arrisxg1v3/tmp/work/mips32el-rdk-linux/eglibc/2.19-r0/eglibc-2.19/libc/stdlib/exit.c:82 (0x8)