### PR TITLE
Fix for the "ThreadedCompositor crash on exit" problem

### DIFF
--- a/Source/WebKit2/WebProcess/WebPage/wpe/DrawingAreaWPE.cpp
+++ b/Source/WebKit2/WebProcess/WebPage/wpe/DrawingAreaWPE.cpp
@@ -25,6 +25,8 @@ DrawingAreaWPE::DrawingAreaWPE(WebPage& webPage, const WebPageCreationParameters
 
 DrawingAreaWPE::~DrawingAreaWPE()
 {
+    if (m_layerTreeHost)
+        m_layerTreeHost->invalidate();
 }
 
 void DrawingAreaWPE::layerHostDidFlushLayers()


### PR DESCRIPTION
We've noticed repeated crashes on the crash portal. The crashes seem to happen upon exit (__run_exit_handlers is running).
The problem seems to be caused by accessing resources (here accessing a string by getLocation) that was already freed by another tread. In other words CompositingRunLoop keep running while necessary resources are already destroyed.
getLocation is called by ThreadedCompositor through the CompositingRunLoop. Seems like DisplayRefreshMonitor keep trigger updates that lead to one shot fires by CompositingRunLoop.
Adding invalidate to the destructor should stop CompositingRunLoop updates as well as invalidate the DisplayRefreshMonitor

Stacktrace:
Crash thread #10
Frame	Signature	Module	Source
Thread #0
Frame	Signature	Module	Source

(cherry picked from commit 9eb8f51f67db3168b667796a40449a394723d572)