### PR TITLE
Add a pointer assertion to MediaPlayerPrivateGStreamerMSE::buffered()

### DIFF
--- a/Source/WebCore/platform/graphics/MediaPlayer.cpp
+++ b/Source/WebCore/platform/graphics/MediaPlayer.cpp
@@ -814,6 +814,7 @@ void MediaPlayer::setPreservesPitch(bool preservesPitch)
 
 std::unique_ptr<PlatformTimeRanges> MediaPlayer::buffered()
 {
+    RELEASE_ASSERT(m_private.get() != nullptr);
     return m_private->buffered();
 }
 

--- a/Source/WebCore/platform/graphics/gstreamer/mse/MediaPlayerPrivateGStreamerMSE.cpp
+++ b/Source/WebCore/platform/graphics/gstreamer/mse/MediaPlayerPrivateGStreamerMSE.cpp
@@ -482,6 +482,7 @@ void MediaPlayerPrivateGStreamerMSE::setRate(float)
 
 std::unique_ptr<PlatformTimeRanges> MediaPlayerPrivateGStreamerMSE::buffered() const
 {
+    RELEASE_ASSERT(m_mediaSource.get() != nullptr);
     return m_mediaSource->buffered();
 }
 


### PR DESCRIPTION
Add a pointer assertion to MediaPlayer::buffered() and MediaPlayerPrivateGStreamerMSE::buffered()

Reason for this change - occasional crashes (backtrace fragment is following)

#0 WebCore::MediaPlayerPrivateGStreamerMSE::buffered libWPEWebKit.so.0.0.20160901 /mnt/jenkins/workspace/ARRISXG1V3-Yocto-Build/build-arrisxg1v3/tmp/work/mips32el-rdk-linux/wpe-webkit/0.1+gitAUTOINC+4240b9bae8-r0/git/Source/WebCore/platform/graphics/gstreamer/MediaPlayerPrivateGStreamerMSE.cpp:629 (0x0)

#1	WebCore::MediaPlayer::buffered libWPEWebKit.so.0.0.20160901 /mnt/jenkins/workspace/ARRISXG1V3-Yocto-Build/build-arrisxg1v3/tmp/work/mips32el-rdk-linux/wpe-webkit/0.1+gitAUTOINC+4240b9bae8-r0/git/Source/WebCore/platform/graphics/MediaPlayer.cpp:821 (0x0)

Narrowing down the crash cause with these two checks would be helpful to find a solution for the crash.