### PR TITLE
Make Web Inspector Remote to listen on both IPv4 and IPv6 addresses

### DIFF
--- a/Source/WebKit2/UIProcess/wpe/WebProcessPoolWPE.cpp
+++ b/Source/WebKit2/UIProcess/wpe/WebProcessPoolWPE.cpp
@@ -60,13 +60,12 @@ static void initInspectorServer()
         String bindAddress = "127.0.0.1";
         unsigned short port = 2999;
 
-        Vector<String> result;
-        serverAddress.split(':', result);
+        size_t ColonIndex = serverAddress.reverseFind(':');
 
-        if (result.size() == 2) {
-            bindAddress = result[0];
+        if (ColonIndex != notFound) {
+            bindAddress = serverAddress.substring(0,ColonIndex);
             bool ok = false;
-            port = result[1].toInt(&ok);
+            port = (serverAddress.substring(ColonIndex+1)).toInt(&ok);
             if (!ok) {
                 port = 2999;
                 LOG_ERROR("Couldn't parse the port. Use 2999 instead.");


### PR DESCRIPTION
Issue Summary: Web Inspector not accessible in Ipv6 mode.
Cause: The existing parsing code for the Environmental variable "WEBKIT_INSPECTOR_SERVER" is coded to parse ipv4 only.
Fix: Modified the code to parse ipv6.
Test Procedure: 
1. Set the Environmental variable WEBKIT_INSPECTOR_SERVER=:::9222. 
2. Add iptable rules using iptables(ipv4) or ip6tables(ipv6) if nedded.
3. In the browser give the URL: http://[ipv6 address of STB]:9222 
4. The web Inspector page will open.
Tested Conditions:
![screenshot-1](https://cloud.githubusercontent.com/assets/27008831/26409184/7615ae2a-40bd-11e7-874a-a99ea7aa7e7c.png)
