### PR TITLE
Fix MSE video size test failures

### DIFF
--- a/Source/WebCore/platform/graphics/gstreamer/mse/MediaPlayerPrivateGStreamerMSE.cpp
+++ b/Source/WebCore/platform/graphics/gstreamer/mse/MediaPlayerPrivateGStreamerMSE.cpp
@@ -787,6 +787,17 @@ bool MediaPlayerPrivateGStreamerMSE::supportsCodecs(const String& codecs)
     return true;
 }
 
+FloatSize MediaPlayerPrivateGStreamerMSE::naturalSize() const
+{
+    if (!hasVideo())
+        return FloatSize();
+
+    if (!m_videoSize.isEmpty())
+        return m_videoSize;
+
+    return MediaPlayerPrivateGStreamerBase::naturalSize();
+}
+
 MediaPlayer::SupportsType MediaPlayerPrivateGStreamerMSE::supportsType(const MediaEngineSupportParameters& parameters)
 {
     MediaPlayer::SupportsType result = MediaPlayer::IsNotSupported;

--- a/Source/WebCore/platform/graphics/gstreamer/mse/MediaPlayerPrivateGStreamerMSE.h
+++ b/Source/WebCore/platform/graphics/gstreamer/mse/MediaPlayerPrivateGStreamerMSE.h
@@ -53,6 +53,8 @@ public:
     void load(const String&) override;
     void load(const String&, MediaSourcePrivateClient*) override;
 
+    FloatSize naturalSize() const override;
+
     void setDownloadBuffering() override { };
 
     bool isLiveStream() const override { return false; }


### PR DESCRIPTION
Reintroducing the commit from pull request https://github.com/WebPlatformForEmbedded/WPEWebKit/pull/46 and commit https://github.com/WebPlatformForEmbedded/WPEWebKit/commit/477c726a7ea1137e116c0eaf489ede409206974b

I guess this was somehow missed during mse code migration.

This is needed to prevent the tests 2,3 & 68 from failing.
Test link: https://yt-dash-mse-test.commondatastorage.googleapis.com/unit-tests/2017.html 
