### PR TITLE
Fix MSE video size test failures (#276)

### DIFF
--- a/Source/WebCore/platform/graphics/gstreamer/mse/MediaPlayerPrivateGStreamerMSE.cpp
+++ b/Source/WebCore/platform/graphics/gstreamer/mse/MediaPlayerPrivateGStreamerMSE.cpp
@@ -787,6 +787,17 @@ bool MediaPlayerPrivateGStreamerMSE::supportsCodecs(const String& codecs)
     return true;
 }
 
+FloatSize MediaPlayerPrivateGStreamerMSE::naturalSize() const
+{
+    if (!hasVideo())
+        return FloatSize();
+
+    if (!m_videoSize.isEmpty())
+        return m_videoSize;
+
+    return MediaPlayerPrivateGStreamerBase::naturalSize();
+}
+
 MediaPlayer::SupportsType MediaPlayerPrivateGStreamerMSE::supportsType(const MediaEngineSupportParameters& parameters)
 {
     MediaPlayer::SupportsType result = MediaPlayer::IsNotSupported;

--- a/Source/WebCore/platform/graphics/gstreamer/mse/MediaPlayerPrivateGStreamerMSE.h
+++ b/Source/WebCore/platform/graphics/gstreamer/mse/MediaPlayerPrivateGStreamerMSE.h
@@ -53,6 +53,8 @@ public:
     void load(const String&) override;
     void load(const String&, MediaSourcePrivateClient*) override;
 
+    FloatSize naturalSize() const override;
+
     void setDownloadBuffering() override { };
 
     bool isLiveStream() const override { return false; }


### PR DESCRIPTION
This is needed to prevent the YouTube conformance tests 2,3 & 68 from failing.
Test link: https://yt-dash-mse-test.commondatastorage.googleapis.com/unit-tests/2017.html

Tested also with YouTube 2016 tests. Causes no regressions, so it's good to go.

This is a cherry-pick from stable branch commit be1ba95fce6d86a9893938ac0da783ec02eb1c0a

