### PR TITLE
Fixed MediaElementsEvents test

### DIFF
--- a/Source/WebCore/platform/graphics/gstreamer/mse/MediaPlayerPrivateGStreamerMSE.h
+++ b/Source/WebCore/platform/graphics/gstreamer/mse/MediaPlayerPrivateGStreamerMSE.h
@@ -81,6 +81,7 @@ public:
     MediaSourcePrivateClient* mediaSourcePrivateClient() { return m_mediaSource.get(); }
 
     void markEndOfStream(MediaSourcePrivate::EndOfStreamStatus);
+    void unmarkEndOfStream();
 
 #if ENABLE(LEGACY_ENCRYPTED_MEDIA_V1) || ENABLE(LEGACY_ENCRYPTED_MEDIA)
     void dispatchDecryptionKey(GstBuffer*) override;

--- a/Source/WebCore/platform/graphics/gstreamer/mse/MediaSourceClientGStreamerMSE.cpp
+++ b/Source/WebCore/platform/graphics/gstreamer/mse/MediaSourceClientGStreamerMSE.cpp
@@ -154,6 +154,16 @@ void MediaSourceClientGStreamerMSE::markEndOfStream(MediaSourcePrivate::EndOfStr
     m_playerPrivate->markEndOfStream(status);
 }
 
+void MediaSourceClientGStreamerMSE::unmarkEndOfStream()
+{
+    ASSERT(WTF::isMainThread());
+
+    if (!m_playerPrivate)
+        return;
+
+    m_playerPrivate->unmarkEndOfStream();
+}
+
 void MediaSourceClientGStreamerMSE::removedFromMediaSource(RefPtr<SourceBufferPrivateGStreamer> sourceBufferPrivate)
 {
     ASSERT(WTF::isMainThread());

--- a/Source/WebCore/platform/graphics/gstreamer/mse/MediaSourceClientGStreamerMSE.h
+++ b/Source/WebCore/platform/graphics/gstreamer/mse/MediaSourceClientGStreamerMSE.h
@@ -44,6 +44,7 @@ public:
     MediaSourcePrivate::AddStatus addSourceBuffer(RefPtr<SourceBufferPrivateGStreamer>, const ContentType&);
     void durationChanged(const MediaTime&);
     void markEndOfStream(MediaSourcePrivate::EndOfStreamStatus);
+    void unmarkEndOfStream();
 
     // From SourceBufferPrivateGStreamer.
     void abort(RefPtr<SourceBufferPrivateGStreamer>);

--- a/Source/WebCore/platform/graphics/gstreamer/mse/MediaSourceGStreamer.cpp
+++ b/Source/WebCore/platform/graphics/gstreamer/mse/MediaSourceGStreamer.cpp
@@ -99,7 +99,7 @@ void MediaSourceGStreamer::markEndOfStream(EndOfStreamStatus status)
 
 void MediaSourceGStreamer::unmarkEndOfStream()
 {
-    notImplemented();
+    m_client->unmarkEndOfStream();
 }
 
 MediaPlayer::ReadyState MediaSourceGStreamer::readyState() const


### PR DESCRIPTION
http://yt-dash-mse-test.commondatastorage.googleapis.com/unit-tests/2016.html

Test consists of
1. Push video buffers ~1s, audio buffers ~60s
   Duration is fetched from pipeline and it is ~1s
2. MSE.duration=1
   All buffers more than 1s and less than current duration should be purged.
3. MSE.endOfStream() - makes current duration as highest reported time in source buffers.
   And it is 60s
4. play()

The test fails due to either timeout 30 is reached (because audio is still playing, when video stopped already)
(and current position (pts) will never be greater than duration 60s),
or pts is not changing at all due to it is reported from video decoder which returns pts of last frame which is less than 1s,
i.e. pts is stuck.

1. Introduced a fix for 2) when duration is changed and it is less than current
all buffers from current duration to highest reported time removed. It leads to have proper duration aftet endOfStream (1s currently instead of 60s).

2. Introduced a fix to check if pts is stuck and there is no playbackprogress and the gap between pts and duration is less than 1s,
means we could define it as EOS.