### PR TITLE
Fix for wpe PageClient overrides

### DIFF
--- a/Source/WebKit2/UIProcess/API/wpe/PageClientImpl.cpp
+++ b/Source/WebKit2/UIProcess/API/wpe/PageClientImpl.cpp
@@ -285,7 +285,7 @@ void PageClientImpl::derefView()
 {
 }
 
-#if ENABLE(VIDEO)
+#if ENABLE(VIDEO) && USE(GSTREAMER)
 bool PageClientImpl::decidePolicyForInstallMissingMediaPluginsPermissionRequest(InstallMissingMediaPluginsPermissionRequest&)
 {
     return false;

--- a/Source/WebKit2/UIProcess/API/wpe/PageClientImpl.h
+++ b/Source/WebKit2/UIProcess/API/wpe/PageClientImpl.h
@@ -114,7 +114,7 @@ private:
     virtual void refView() override;
     virtual void derefView() override;
 
-#if ENABLE(VIDEO)
+#if ENABLE(VIDEO) && USE(GSTREAMER)
     virtual bool decidePolicyForInstallMissingMediaPluginsPermissionRequest(InstallMissingMediaPluginsPermissionRequest&) override;
 #endif
 


### PR DESCRIPTION
Function definition is wrapped with `USE(GSTREAMER)`

https://github.com/WebPlatformForEmbedded/WPEWebKit/blob/master/Source/WebKit2/UIProcess/PageClient.h#L367