### PR TITLE
Fixed UI issues in webinspector

### DIFF
--- a/Source/WebInspectorUI/UserInterface/Views/NavigationSidebarPanel.css
+++ b/Source/WebInspectorUI/UserInterface/Views/NavigationSidebarPanel.css
@@ -65,10 +65,8 @@
 }
 
 .sidebar > .panel.navigation > .content > .empty-content-placeholder {
-    position: absolute;
     top: 0;
     bottom: 0;
-    padding: 0;
 }
 
 .sidebar > .panel.navigation > .content .empty-content-placeholder > .message {

--- a/Source/WebInspectorUI/UserInterface/Views/ResourceSidebarPanel.css
+++ b/Source/WebInspectorUI/UserInterface/Views/ResourceSidebarPanel.css
@@ -28,7 +28,6 @@
 }
 
 .sidebar > .panel.navigation.resource > .navigation-bar {
-    position: absolute;
     top: 0;
     left: 0;
     right: 0;

--- a/Source/WebInspectorUI/UserInterface/Views/ResourceSidebarPanel.js
+++ b/Source/WebInspectorUI/UserInterface/Views/ResourceSidebarPanel.js
@@ -34,7 +34,7 @@ WebInspector.ResourceSidebarPanel = class ResourceSidebarPanel extends WebInspec
         this.filterBar.placeholder = WebInspector.UIString("Filter Resource List");
 
         this._navigationBar = new WebInspector.NavigationBar;
-        this.addSubview(this._navigationBar);
+        this.insertSubviewBefore(this._navigationBar, this._contentView);
 
         this._targetTreeElementMap = new Map;
 

--- a/Source/WebInspectorUI/UserInterface/Views/SidebarPanel.css
+++ b/Source/WebInspectorUI/UserInterface/Views/SidebarPanel.css
@@ -24,7 +24,6 @@
  */
 
 .sidebar > .panel > .content {
-    position: absolute;
     top: 0;
     left: 0;
     right: 0;

--- a/Source/WebInspectorUI/UserInterface/Views/StorageSidebarPanel.css
+++ b/Source/WebInspectorUI/UserInterface/Views/StorageSidebarPanel.css
@@ -28,7 +28,6 @@
 }
 
 .sidebar > .panel.navigation.storage > .navigation-bar {
-    position: absolute;
     top: 0;
     left: 0;
     right: 0;

--- a/Source/WebInspectorUI/UserInterface/Views/StorageSidebarPanel.js
+++ b/Source/WebInspectorUI/UserInterface/Views/StorageSidebarPanel.js
@@ -34,7 +34,7 @@ WebInspector.StorageSidebarPanel = class StorageSidebarPanel extends WebInspecto
         this.filterBar.placeholder = WebInspector.UIString("Filter Storage List");
 
         this._navigationBar = new WebInspector.NavigationBar;
-        this.addSubview(this._navigationBar);
+        this.insertSubviewBefore(this._navigationBar, this._contentView);
 
         var scopeItemPrefix = "storage-sidebar-";
         var scopeBarItems = [];


### PR DESCRIPTION
Some items from Resources and Storage tabs have been inaccessible and hidden by wrong css.
Applied a fix to keep navigation bar always first and before content.
Secondly removed absolute position to prevent overlapping.