### PR TITLE
Fix video playback stutter/stop while playing youtube/tv video @ 1080p

### DIFF
--- a/Source/WebCore/platform/graphics/gstreamer/mse/GStreamerMediaSample.h
+++ b/Source/WebCore/platform/graphics/gstreamer/mse/GStreamerMediaSample.h
@@ -27,6 +27,7 @@
 #include "MediaSample.h"
 #include <gst/gst.h>
 #include <wtf/text/AtomicString.h>
+#include <wtf/PrintStream.h>
 
 namespace WebCore {
 
@@ -55,7 +56,7 @@ public:
     Ref<MediaSample> createNonDisplayingCopy() const override;
     SampleFlags flags() const override { return m_flags; }
     PlatformSample platformSample() override  { return PlatformSample(); }
-    void dump(PrintStream&) const override { }
+    void dump(PrintStream& out) const override { out.print("{PTS(", presentationTime(), "), DTS(", decodeTime(), "), duration(", duration(), ")}"); }
 
 private:
     GStreamerMediaSample(GstSample*, const FloatSize& presentationSize, const AtomicString& trackId);

--- a/Source/WebCore/platform/graphics/gstreamer/mse/MediaPlayerPrivateGStreamerMSE.h
+++ b/Source/WebCore/platform/graphics/gstreamer/mse/MediaPlayerPrivateGStreamerMSE.h
@@ -116,6 +116,7 @@ private:
     unsigned long corruptedVideoFrames() override { return 0; }
     MediaTime totalFrameDelay() override { return MediaTime::zeroTime(); }
     bool isTimeBuffered(const MediaTime&) const;
+    bool playbackPipelineHasFutureData() const;
 
     bool isMediaSource() const override { return true; }
 

--- a/Source/WebCore/platform/graphics/gstreamer/mse/PlaybackPipeline.cpp
+++ b/Source/WebCore/platform/graphics/gstreamer/mse/PlaybackPipeline.cpp
@@ -133,7 +133,7 @@ MediaSourcePrivate::AddStatus PlaybackPipeline::addSourceBuffer(RefPtr<SourceBuf
     gst_app_src_set_emit_signals(GST_APP_SRC(stream->appsrc), FALSE);
     gst_app_src_set_stream_type(GST_APP_SRC(stream->appsrc), GST_APP_STREAM_TYPE_SEEKABLE);
 
-    gst_app_src_set_max_bytes(GST_APP_SRC(stream->appsrc), 2 * WTF::MB);
+    gst_app_src_set_max_bytes(GST_APP_SRC(stream->appsrc), 8 * WTF::MB);
     g_object_set(G_OBJECT(stream->appsrc), "block", FALSE, "min-percent", 20, "format", GST_FORMAT_TIME, nullptr);
 
     GST_OBJECT_LOCK(m_webKitMediaSrc.get());

--- a/Source/WebCore/platform/graphics/gstreamer/mse/PlaybackPipeline.h
+++ b/Source/WebCore/platform/graphics/gstreamer/mse/PlaybackPipeline.h
@@ -68,6 +68,8 @@ public:
     void flush(AtomicString);
     void enqueueSample(RefPtr<MediaSample>);
 
+    bool hasFutureData(const MediaTime& start);
+
     GstElement* pipeline();
 private:
     PlaybackPipeline() = default;

--- a/Source/WebCore/platform/graphics/gstreamer/mse/WebKitMediaSourceGStreamerPrivate.h
+++ b/Source/WebCore/platform/graphics/gstreamer/mse/WebKitMediaSourceGStreamerPrivate.h
@@ -69,6 +69,7 @@ struct _Stream {
 
     // Used to enforce continuity in the appended data and avoid breaking the decoder.
     MediaTime lastEnqueuedTime;
+    MediaTime firstEnqueuedTime;
 };
 
 enum {


### PR DESCRIPTION
Usually, it is easily reproducible on game videos when it plays in 1080p@60:
https://www.youtube.com/tv/#/watch/video/control?v=mwVjTx5WxHU&resume&env_isVideoInfoVisible=true

The coded frames evicttion algorithm fails to free enough room after some time of playback and throws the QUOTA_EXCEEDED_ERR. 

Youtube reacts by removing all the buffered frames which make WPE to pause video playback internally. After that youtube doesn't provide more data. Presumably, it waits for video playback to progress a little to continue appending video data.

The patch set tries to avoid throwing the QUOTA_EXCEEDED_ERR, also it tries to keep video playback going if there is enough data in playback pipeline which gives the app a chance to provide more data.