### PR TITLE
Fixed bug with unneeded rangeRemoval

### DIFF
--- a/Source/WebCore/Modules/mediasource/MediaSource.cpp
+++ b/Source/WebCore/Modules/mediasource/MediaSource.cpp
@@ -508,10 +508,12 @@ ExceptionOr<void> MediaSource::setDurationInternal(const MediaTime& duration)
 
     // 4. If the new duration is less than old duration, then call remove(new duration, old duration)
     // on all objects in sourceBuffers.
-    for (auto& sourceBuffer : *m_sourceBuffers) {
-        auto length = sourceBuffer->bufferedInternal().length();
-        if (length && newDuration < sourceBuffer->bufferedInternal().ranges().end(length - 1))
-            sourceBuffer->rangeRemoval(newDuration, sourceBuffer->bufferedInternal().ranges().end(length - 1));
+    if (m_duration.isValid() && newDuration < m_duration) {
+        for (auto& sourceBuffer : *m_sourceBuffers) {
+            auto length = sourceBuffer->bufferedInternal().length();
+            if (length && newDuration < sourceBuffer->bufferedInternal().ranges().end(length - 1))
+                sourceBuffer->rangeRemoval(newDuration, sourceBuffer->bufferedInternal().ranges().end(length - 1));
+        }
     }
 #else
     // Upstream implementation, conforming to the latest MSE spec.


### PR DESCRIPTION
MediaSource::setDurationInternal previously was supposed to remove
buffer ranges if the new duration is less than old duration.
It has been changed to remove all ranges that more that new duration.
It caused RC and MediaElementEvents test failed.

Due to

1. SourceBuffer::rangeRemoval sets m_updating = true; and starts a timer
(SourceBuffer::removeTimerFired() where m_updating = false)

2. (When ms.duration = 1 is called from JavaScript)
MediaSource::setDuration is called and checks

        for (auto& sourceBuffer : *m_sourceBuffers) {
             if (sourceBuffer->updating()){
                 return Exception { INVALID_STATE_ERR };
             }
        }

And an exception is thrown. Because SourceBuffer::removeTimerFired() is not emitted yet.

So needs to remove ranges only if new duration is less than current.