### PR TITLE
[MSE][GStreamer] Fix premature video clip change on youtube

### DIFF
--- a/Source/WebCore/platform/graphics/gstreamer/mse/MediaPlayerPrivateGStreamerMSE.cpp
+++ b/Source/WebCore/platform/graphics/gstreamer/mse/MediaPlayerPrivateGStreamerMSE.cpp
@@ -883,7 +883,7 @@ MediaTime MediaPlayerPrivateGStreamerMSE::currentMediaTime() const
     MediaTime position = MediaPlayerPrivateGStreamer::currentMediaTime();
     MediaTime playbackProgress = abs(position - cachedPosition);
 
-    if (m_eosPending && (paused() || (abs(position - durationMediaTime()) <= MediaTime::createWithDouble(1) && !playbackProgress))) {
+    if (m_eosPending && abs(position - durationMediaTime()) < MediaTime::createWithDouble(1) && !playbackProgress) {
         if (m_networkState != MediaPlayer::Loaded) {
             m_networkState = MediaPlayer::Loaded;
             m_player->networkStateChanged();


### PR DESCRIPTION
Reproducible when user pauses playback on fully buffered video, usually
10-15 seconds near the end.

The change reduces the reproduction case to less than a 1 second near the end.