### PR TITLE
[GStreamer] Fix for invalid video size information sometimes returned…

### DIFF
--- a/Source/WebCore/platform/graphics/gstreamer/MediaPlayerPrivateGStreamerBase.cpp
+++ b/Source/WebCore/platform/graphics/gstreamer/MediaPlayerPrivateGStreamerBase.cpp
@@ -630,6 +630,13 @@ FloatSize MediaPlayerPrivateGStreamerBase::naturalSize() const
     if (!getVideoSizeAndFormatFromCaps(caps.get(), originalSize, format, pixelAspectRatioNumerator, pixelAspectRatioDenominator, stride))
         return FloatSize();
 
+    // Sanity check for the unlikely, but reproducible case when getVideoSizeAndFormatFromCaps returns incorrect values
+    if ((originalSize.width() == 0) || (originalSize.height() == 0)
+       || (pixelAspectRatioNumerator == 0) || (pixelAspectRatioNumerator == 0)) {
+        GST_DEBUG("getVideoSizeAndFormatFromCaps returned an invalid info, returning an empty size");
+        return FloatSize();
+    }
+
 #if USE(TEXTURE_MAPPER_GL)
     // When using accelerated compositing, if the video is tagged as rotated 90 or 270 degrees, swap width and height.
     if (m_player->client().mediaPlayerRenderingCanBeAccelerated(m_player)) {


### PR DESCRIPTION
… by getVideoSizeAndFormatFromCaps (gst_video_info_from_caps)

This pull request is created so master would also contain these changes already approved for stable:
https://github.com/WebPlatformForEmbedded/WPEWebKit/pull/332