### PR TITLE
Live shoutcast AAC radio stream fixes

### DIFF
--- a/Source/WebCore/platform/graphics/gstreamer/MediaPlayerPrivateGStreamer.cpp
+++ b/Source/WebCore/platform/graphics/gstreamer/MediaPlayerPrivateGStreamer.cpp
@@ -494,6 +494,9 @@ void MediaPlayerPrivateGStreamer::play()
         m_isEndReached = false;
         m_delayingLoad = false;
         m_preload = MediaPlayer::Auto;
+        // make sure we properly detect live stream on play
+        if(!isMediaSource()) 
+            totalBytes();
         setDownloadBuffering();
         GST_DEBUG("Play");
     } else {
@@ -2054,7 +2057,7 @@ void MediaPlayerPrivateGStreamer::setDownloadBuffering()
     unsigned flagDownload = getGstPlayFlag("download");
 
     // We don't want to stop downloading if we already started it.
-    if (flags & flagDownload && m_readyState > MediaPlayer::HaveNothing && !m_resetPipeline)
+    if (flags & flagDownload && m_readyState > MediaPlayer::HaveNothing && !m_resetPipeline && !isLiveStream())
         return;
 
     bool shouldDownload = !isLiveStream() && m_preload == MediaPlayer::Auto && !isMediaDiskCacheDisabled();

--- a/Source/WebCore/platform/graphics/gstreamer/WebKitWebSourceGStreamer.cpp
+++ b/Source/WebCore/platform/graphics/gstreamer/WebKitWebSourceGStreamer.cpp
@@ -955,6 +955,16 @@ void StreamingClient::handleResponseReceived(const ResourceResponse& response)
         gst_app_src_set_size(priv->appsrc, -1);
 
     gst_app_src_set_caps(priv->appsrc, 0);
+    String value = response.httpHeaderField(HTTPHeaderName::IcyMetaInt);
+    if (!value.isEmpty()) {
+        gchar* endptr = 0;
+        gint64 icyMetaInt = g_ascii_strtoll(value.utf8().data(), &endptr, 10);
+
+        if (endptr && *endptr == '\0' && icyMetaInt > 0) {
+            GRefPtr<GstCaps> caps = adoptGRef(gst_caps_new_simple("application/x-icy", "metadata-interval", G_TYPE_INT, (gint) icyMetaInt, NULL));
+            gst_app_src_set_caps(priv->appsrc, caps.get());
+      }
+    }
 }
 
 void StreamingClient::handleDataReceived(const char* data, int length)


### PR DESCRIPTION
This is mainly fixes for live shoutcast aac radio streams using http://tv.iheart.com/comcast/

**[Gstreamer] Make sure live stream is detected**
The lives streams weren't detected as live until too late causing disk buffering to be never turned off causing a dropout at the beginning of play.

**[Gstreamer] Assure icy metadata is detected**
i pulled this change from our old webkit port.  Because of this line in WebKitWebSourceGStreamer.cpp:
`// We always request Icecast/Shoutcast metadata, just in case ...
request.setHTTPHeaderField(HTTPHeaderName::IcyMetadata, “1”)`

It causes the icy meta data to be put into the stream.  But playbin doesn't detect this and passes the data through typefind to aacparse, but the Icy metadata is messing up aac parse causing constant small hiccups and eventual total dropouts.  The proposed commit adds the icy caps back so icy demux is added to the pipeline.  Removing the Icy request will also fix the issue since no metadata will then be in the pipeline.  I'm not sure what the reason to request Icy metadata is now that all other Icy/iradio stuff has been removed from WebkitWebSourceGstreamer over the years.

