### PR TITLE
[EMEv1] Fix crashes in YouTube 2016 EME tests.

### DIFF
--- a/Source/WebCore/platform/graphics/gstreamer/mse/AppendPipeline.cpp
+++ b/Source/WebCore/platform/graphics/gstreamer/mse/AppendPipeline.cpp
@@ -473,7 +473,8 @@ void AppendPipeline::setAppendState(AppendState newAppendState)
         case AppendState::Invalid:
             ok = true;
 #if ENABLE(LEGACY_ENCRYPTED_MEDIA_V1) || ENABLE(LEGACY_ENCRYPTED_MEDIA)
-            m_playerPrivate->abortEncryptionSetup();
+            if (m_playerPrivate)
+                m_playerPrivate->abortEncryptionSetup();
 #endif
             break;
         default:


### PR DESCRIPTION
Protect against use of nullptr when calling abortEncryptionSetup.

MediaPlayerPrivateGStreamerMSE calls clearPlayerPrivate, which sets the
m_playerPrivate of the AppendPipeline to nullptr. It then removes the
AppendPipeline from the map, which causes a destruction which causes a
setAppendState(Invalid) which causes another call to abortEncryptionSetup which
calls a method on m_playerPrivate, which is now nullptr, which causes dragons
to fly out the nostrils.

I spent a lot of time trying to do away with m_playerPrivate being a nullable
pointer (make the PrivateMSE class inherit from ThreadSafeRefCounted and apply
the refactoring process). This cleans up *a lot* of code, but the debugging
assertions of the Ref objects were pointing to thread-safety issues I didn't
have time to continue with. This refactoring was out-of-hand, but it is
something that will need to be revisted: a clear way to see the lifetimes of
the various media classes, and not this taking addresses of references to base
class members, controlling state by setting these pointers to null. The lifetime
of the private player should be guarenteed, but convincing yourself of this
with the media class interactions, and the ramifications on the lifetimes of
those interactions, is not trivial.

Test all YouTube conformance tests and noticed no regressions, also
checked the "smoke" test on eme.html?type=lg and there were no errors.