### PR TITLE
Fixed debugger overlap

### DIFF
--- a/Source/WebInspectorUI/UserInterface/Views/TreeOutline.css
+++ b/Source/WebInspectorUI/UserInterface/Views/TreeOutline.css
@@ -26,7 +26,6 @@
 .tree-outline,
 .tree-outline .children {
     padding: 0;
-    margin: 0;
 
     outline: none;
 


### PR DESCRIPTION
UI webinspector contains simple overlap in left side of debugger tab.
Just needed to remove spaces around an item.