### PR TITLE
Fixed UI issues in webinspector

### DIFF
--- a/Source/WebInspectorUI/UserInterface/Views/DebuggerSidebarPanel.css
+++ b/Source/WebInspectorUI/UserInterface/Views/DebuggerSidebarPanel.css
@@ -28,7 +28,6 @@
 }
 
 .sidebar > .panel.navigation.debugger > .navigation-bar {
-    position: absolute;
     top: 0;
     left: 0;
     right: 0;

--- a/Source/WebInspectorUI/UserInterface/Views/DebuggerSidebarPanel.js
+++ b/Source/WebInspectorUI/UserInterface/Views/DebuggerSidebarPanel.js
@@ -65,7 +65,7 @@ WebInspector.DebuggerSidebarPanel = class DebuggerSidebarPanel extends WebInspec
         enableBreakpointsLink.addEventListener("click", () => { WebInspector.debuggerToggleBreakpoints(); });
 
         this._navigationBar = new WebInspector.NavigationBar;
-        this.addSubview(this._navigationBar);
+        this.insertSubviewBefore(this._navigationBar, this._contentView);
 
         var breakpointsImage = {src: "Images/Breakpoints.svg", width: 15, height: 15};
         var pauseImage = {src: "Images/Pause.svg", width: 15, height: 15};

--- a/Source/WebInspectorUI/UserInterface/Views/NetworkSidebarPanel.css
+++ b/Source/WebInspectorUI/UserInterface/Views/NetworkSidebarPanel.css
@@ -28,14 +28,12 @@
 }
 
 .sidebar > .panel.navigation.network > .navigation-bar {
-    position: absolute;
     top: 0;
     left: 0;
     right: 0;
 }
 
 .sidebar > .panel.navigation.network > .title-bar {
-    position: absolute;
     top: var(--navigation-bar-height);
     left: 0;
     right: 0;

--- a/Source/WebInspectorUI/UserInterface/Views/NetworkSidebarPanel.js
+++ b/Source/WebInspectorUI/UserInterface/Views/NetworkSidebarPanel.js
@@ -34,12 +34,12 @@ WebInspector.NetworkSidebarPanel = class NetworkSidebarPanel extends WebInspecto
         this.filterBar.placeholder = WebInspector.UIString("Filter Resource List");
 
         this._navigationBar = new WebInspector.NavigationBar;
-        this.addSubview(this._navigationBar);
+        this.insertSubviewBefore(this._navigationBar, this._contentView);
 
         this._resourcesTitleBarElement = document.createElement("div");
         this._resourcesTitleBarElement.textContent = WebInspector.UIString("Name");
         this._resourcesTitleBarElement.classList.add("title-bar");
-        this.element.appendChild(this._resourcesTitleBarElement);
+        this.element.insertBefore(this._resourcesTitleBarElement, this._contentView.element);
 
         var scopeItemPrefix = "network-sidebar-";
         var scopeBarItems = [];


### PR DESCRIPTION
Some items from Network and Debugger tabs have been inaccessible and hidden by wrong css.
Applied a fix to keep navigation and title bar always first and before content.
Secondly removed absolute position to prevent overlapping.