### PR TITLE
[Media] Don't throw exception when controls are hidden

### DIFF
--- a/Source/WebCore/Modules/mediacontrols/mediaControlsBase.js
+++ b/Source/WebCore/Modules/mediacontrols/mediaControlsBase.js
@@ -1035,6 +1035,8 @@ Controller.prototype = {
             return false;
 
         var panel = this.controls.panel;
+        if (!panel.parentElement)
+            return true;
         return (!panel.classList.contains(this.ClassNames.show) || panel.classList.contains(this.ClassNames.hidden))
             && (panel.parentElement.querySelector(':hover') !== panel);
     },


### PR DESCRIPTION
This is a workaround for https://github.com/WebPlatformForEmbedded/WPEWebKit/issues/367