### PR TITLE
Check for ENABLE(SVG_FONTS) while using Type::SVGFontResource

### DIFF
--- a/Source/WebCore/loader/cache/CachedResource.cpp
+++ b/Source/WebCore/loader/cache/CachedResource.cpp
@@ -366,7 +366,9 @@ bool CachedResource::isCORSSameOrigin() const
 {
     // Following resource types do not use CORS
     ASSERT(type() != CachedResource::Type::FontResource);
+#if ENABLE(SVG_FONTS)
     ASSERT(type() != CachedResource::Type::SVGFontResource);
+#endif
     ASSERT(type() != CachedResource::XSLStyleSheet);
 
     // https://html.spec.whatwg.org/multipage/infrastructure.html#cors-same-origin


### PR DESCRIPTION
Avoid of compiler errors when compiling in DEBUG mode