### PR TITLE
[GStreamer][MSE] Fix hang on clearing/destroying AppendPipeline

### DIFF
--- a/Source/WebCore/platform/graphics/gstreamer/mse/AppendPipeline.cpp
+++ b/Source/WebCore/platform/graphics/gstreamer/mse/AppendPipeline.cpp
@@ -1062,6 +1062,9 @@ void AppendPipeline::connectDemuxerSrcPadToAppsinkFromAnyThread(GstPad* demuxerS
         GST_TRACE("demuxer-connect-to-appsink message posted to bus");
 
         m_padAddRemoveCondition.wait(m_padAddRemoveLock);
+
+        if (!m_playerPrivate)
+            return;
     }
 
     // Must be done in the thread we were called from (usually streaming thread).


### PR DESCRIPTION
The deadlock may occur when UI thread tries to clear pipeline in
AppendPipeline::clearPlayerPrivate() while parser thread tries to change
pipeline state to pause holding the stream lock in
AppendPipeline::connectDemuxerSrcPadToAppsinkFromAnyThread()