### PR TITLE
fix for crashes during auto switch of videos in YouTube

### DIFF
--- a/Source/WebCore/platform/graphics/texmap/coordinated/CoordinatedGraphicsLayer.cpp
+++ b/Source/WebCore/platform/graphics/texmap/coordinated/CoordinatedGraphicsLayer.cpp
@@ -140,6 +140,9 @@ CoordinatedGraphicsLayer::CoordinatedGraphicsLayer(Type layerType, GraphicsLayer
 
 CoordinatedGraphicsLayer::~CoordinatedGraphicsLayer()
 {
+    if (m_platformLayer)
+        m_platformLayer->setClient(nullptr);
+
     if (m_coordinator) {
         purgeBackingStores();
         m_coordinator->detachLayer(this);


### PR DESCRIPTION
We got following crashes..
because of improper cleanup in "CoordinatedGraphicsLayer"
Thread 1 (LWP 13574):
#0  0x76dd2fec in ~MediaPlayerPrivateGStreamerBase ()
    at /mnt/home/bselva200/10-10-17-arrisxg1v3/build-arrisxg1v3/tmp/work/mips32el-rdk-linux/wpe-webkit/0.2+gitAUTOINC+b22045fe49-r0/git/Source/WebCore/platform/graphics/gstreamer/MediaPlayerPrivateGStreamerBase.cpp:331
#1  0x76dcddfc in ~MediaPlayerPrivateGStreamer ()
    at /mnt/home/bselva200/10-10-17-arrisxg1v3/build-arrisxg1v3/tmp/work/mips32el-rdk-linux/wpe-webkit/0.2+gitAUTOINC+b22045fe49-r0/git/Source/WebCore/platform/graphics/gstreamer/MediaPlayerPrivateGStreamer.cpp:217
#2  0x76deb0a0 in ~MediaPlayerPrivateGStreamerMSE ()
    at /mnt/home/bselva200/10-10-17-arrisxg1v3/build-arrisxg1v3/tmp/work/mips32el-rdk-linux/wpe-webkit/0.2+gitAUTOINC+b22045fe49-r0/git/Source/WebCore/platform/graphics/gstreamer/mse/MediaPlayerPrivateGStreamerMSE.cpp:138
#3  0x76cbfa84 in operator() () at /mnt/home/bselva200/10-10-17-arrisxg1v3/build-arrisxg1v3/tmp/sysroots/arrisxg1v3/usr/include/c++/bits/unique_ptr.h:76
#4  ~unique_ptr () at /mnt/home/bselva200/10-10-17-arrisxg1v3/build-arrisxg1v3/tmp/sysroots/arrisxg1v3/usr/include/c++/bits/unique_ptr.h:236
#5  ~MediaPlayer () at /mnt/home/bselva200/10-10-17-arrisxg1v3/build-arrisxg1v3/tmp/work/mips32el-rdk-linux/wpe-webkit/0.2+gitAUTOINC+b22045fe49-r0/git/Source/WebCore/platform/graphics/MediaPlayer.cpp:373
#6  0x76cbfb40 in ~MediaPlayer () at /mnt/home/bselva200/10-10-17-arrisxg1v3/build-arrisxg1v3/tmp/work/mips32el-rdk-linux/wpe-webkit/0.2+gitAUTOINC+b22045fe49-r0/git/Source/WebCore/platform/graphics/MediaPlayer.cpp:376
#7  0x765840b4 in operator() () at /mnt/home/bselva200/10-10-17-arrisxg1v3/build-arrisxg1v3/tmp/sysroots/arrisxg1v3/usr/include/c++/bits/unique_ptr.h:76
#8  reset () at /mnt/home/bselva200/10-10-17-arrisxg1v3/build-arrisxg1v3/tmp/sysroots/arrisxg1v3/usr/include/c++/bits/unique_ptr.h:344
#9  operator= () at /mnt/home/bselva200/10-10-17-arrisxg1v3/build-arrisxg1v3/tmp/sysroots/arrisxg1v3/usr/include/c++/bits/unique_ptr.h:251
#10 createMediaPlayer () at /mnt/home/bselva200/10-10-17-arrisxg1v3/build-arrisxg1v3/tmp/work/mips32el-rdk-linux/wpe-webkit/0.2+gitAUTOINC+b22045fe49-r0/git/Source/WebCore/html/HTMLMediaElement.cpp:6140
#11 0x76584af0 in prepareForLoad () at /mnt/home/bselva200/10-10-17-arrisxg1v3/build-arrisxg1v3/tmp/work/mips32el-rdk-linux/wpe-webkit/0.2+gitAUTOINC+b22045fe49-r0/git/Source/WebCore/html/HTMLMediaElement.cpp:1190
#12 0x76589930 in load () at /mnt/home/bselva200/10-10-17-arrisxg1v3/build-arrisxg1v3/tmp/work/mips32el-rdk-linux/wpe-webkit/0.2+gitAUTOINC+b22045fe49-r0/git/Source/WebCore/html/HTMLMediaElement.cpp:1147
#13 0x771336d0 in jsHTMLMediaElementPrototypeFunctionLoadCaller () at DerivedSources/WebCore/JSHTMLMediaElement.cpp:1595
#14 callOperation<WebCore::jsHTMLMediaElementPrototypeFunctionLoadCaller, (WebCore::CastedThisErrorBehavior)0> ()
    at /mnt/home/bselva200/10-10-17-arrisxg1v3/build-arrisxg1v3/tmp/work/mips32el-rdk-linux/wpe-webkit/0.2+gitAUTOINC+b22045fe49-r0/git/Source/WebCore/bindings/js/JSDOMBinding.h:362
#15 jsHTMLMediaElementPrototypeFunctionLoad () at DerivedSources/WebCore/JSHTMLMediaElement.cpp:1587
warning: GDB can't find the start of the function at 0x555f8d5f.
#16 0x555f8d60 in ?? ()
(gdb)