### PR TITLE
[EME] Attach the CDM instance to CDMClient in generateRequest.

### DIFF
--- a/Source/WebCore/Modules/encryptedmedia/CDMClient.h
+++ b/Source/WebCore/Modules/encryptedmedia/CDMClient.h
@@ -38,6 +38,7 @@ class CDMClient {
 public:
     virtual ~CDMClient() { }
 
+    virtual void cdmClientInstanceAttached(const CDMInstance&) = 0;
     virtual void cdmClientAttemptToResumePlaybackIfNecessary() = 0;
     virtual void cdmClientAttemptToDecryptWithInstance(const CDMInstance&) = 0;
 };

--- a/Source/WebCore/Modules/encryptedmedia/MediaKeySession.cpp
+++ b/Source/WebCore/Modules/encryptedmedia/MediaKeySession.cpp
@@ -113,6 +113,11 @@ void MediaKeySession::generateRequest(const AtomicString& initDataType, const Bu
         return;
     }
 
+    m_taskQueue.enqueueTask([this] () mutable {
+        if (m_keys)
+            m_keys->attachInstanceToCDMClients();
+    });
+
     // 3. Let this object's uninitialized value be false.
     m_uninitialized = false;
 

--- a/Source/WebCore/Modules/encryptedmedia/MediaKeys.cpp
+++ b/Source/WebCore/Modules/encryptedmedia/MediaKeys.cpp
@@ -124,6 +124,12 @@ void MediaKeys::detachCDMClient(CDMClient& client)
     m_cdmClients.removeFirst(&client);
 }
 
+void MediaKeys::attachInstanceToCDMClients()
+{
+    for (auto* cdmClient : m_cdmClients)
+        cdmClient->cdmClientInstanceAttached(m_instance);
+}
+
 void MediaKeys::attemptToResumePlaybackOnClients()
 {
     for (auto* cdmClient : m_cdmClients)

--- a/Source/WebCore/Modules/encryptedmedia/MediaKeys.h
+++ b/Source/WebCore/Modules/encryptedmedia/MediaKeys.h
@@ -67,6 +67,8 @@ public:
     bool hasOpenSessions() const;
     const CDMInstance& cdmInstance() const { return m_instance; }
 
+    void attachInstanceToCDMClients();
+
 protected:
     MediaKeys(bool useDistinctiveIdentifier, bool persistentStateAllowed, const Vector<MediaKeySessionType>&, Ref<CDM>&&, Ref<CDMInstance>&&);
 

--- a/Source/WebCore/html/HTMLMediaElement.cpp
+++ b/Source/WebCore/html/HTMLMediaElement.cpp
@@ -2642,8 +2642,6 @@ void HTMLMediaElement::setMediaKeys(MediaKeys* mediaKeys, Ref<DeferredPromise>&&
         if (mediaKeys) {
             // 5.3.1. Associate the CDM instance represented by mediaKeys with the media element for decrypting media data.
             mediaKeys->attachCDMClient(*this);
-            if (m_player)
-                m_player->cdmInstanceAttached(mediaKeys->cdmInstance());
 
             // 5.3.2. If the preceding step failed, run the following steps:
             //   5.3.2.1. Set the mediaKeys attribute to null.
@@ -2685,6 +2683,12 @@ void HTMLMediaElement::mediaPlayerInitializationDataEncountered(const String& in
     //      initData = initData
     MediaEncryptedEventInit initializer { initDataType, WTFMove(initData) };
     m_asyncEventQueue.enqueueEvent(MediaEncryptedEvent::create(eventNames().encryptedEvent, initializer, Event::IsTrusted::Yes));
+}
+
+void HTMLMediaElement::cdmClientInstanceAttached(const CDMInstance& instance)
+{
+    if (m_player)
+        m_player->cdmInstanceAttached(instance);
 }
 
 void HTMLMediaElement::attemptToDecrypt()

--- a/Source/WebCore/html/HTMLMediaElement.h
+++ b/Source/WebCore/html/HTMLMediaElement.h
@@ -652,6 +652,7 @@ private:
     void attemptToResumePlaybackIfNecessary();
 
     // CDMClient
+    void cdmClientInstanceAttached(const CDMInstance&) override;
     void cdmClientAttemptToResumePlaybackIfNecessary() final;
     void cdmClientAttemptToDecryptWithInstance(const CDMInstance&) final;
 #endif


### PR DESCRIPTION
Currently the CDMInstance is attached to the CDMClient (HTMLMediaElement) when setMediaKeys is called.

But when we call setMediaKeys in javascript, we don't know if the MediaPlayer is created yet, thus when we attach the CDMInstance to the CDMClient, we are not sure that the CDMInstance is propagated to the MediaPlayer and then to MediaPlayerPrivate.

The fix consist in attaching the CDMInstance in generateRequest because we are sure at this moment that the MediaPlayer and MediaPlayerPrivate is already created.