### PR TITLE
[GStreamer][MSE] Avoid patching public MediaPlayer to filter mime type values

### DIFF
--- a/Source/WebCore/Modules/mediasource/MediaSource.cpp
+++ b/Source/WebCore/Modules/mediasource/MediaSource.cpp
@@ -861,32 +861,12 @@ bool MediaSource::isTypeSupported(const String& type)
     if (contentType.containerType().isEmpty())
         return false;
 
-    bool ok;
-    unsigned channels = contentType.parameter("channels").toUInt(&ok);
-    if (!ok)
-        channels = 0;
-
-    float width = contentType.parameter("width").toFloat(&ok);
-    if (!ok)
-        width = 0;
-
-    float height = contentType.parameter("height").toFloat(&ok);
-    if (!ok)
-        height = 0;
-
-    float framerate = contentType.parameter("framerate").toFloat(&ok);
-    if (!ok)
-        framerate = 0;
-
     // 3. If type contains a media type or media subtype that the MediaSource does not support, then return false.
     // 4. If type contains at a codec that the MediaSource does not support, then return false.
     // 5. If the MediaSource does not support the specified combination of media type, media subtype, and codecs then return false.
     // 6. Return true.
     MediaEngineSupportParameters parameters;
     parameters.type = contentType;
-    parameters.channels = channels;
-    parameters.dimension = { width, height };
-    parameters.framerate = framerate;
     parameters.isMediaSource = true;
     MediaPlayer::SupportsType supported = MediaPlayer::supportsType(parameters, 0);
 

--- a/Source/WebCore/platform/graphics/MediaPlayer.h
+++ b/Source/WebCore/platform/graphics/MediaPlayer.h
@@ -119,9 +119,6 @@ struct MediaEngineSupportParameters {
     ContentType type;
     URL url;
     String keySystem;
-    unsigned int channels;
-    FloatSize dimension;
-    float framerate;
     bool isMediaSource { false };
     bool isMediaStream { false };
     Vector<ContentType> contentTypesRequiringHardwareSupport;

--- a/Source/WebCore/platform/graphics/gstreamer/mse/MediaPlayerPrivateGStreamerMSE.cpp
+++ b/Source/WebCore/platform/graphics/gstreamer/mse/MediaPlayerPrivateGStreamerMSE.cpp
@@ -941,14 +941,25 @@ MediaPlayer::SupportsType MediaPlayerPrivateGStreamerMSE::supportsType(const Med
 
     // We shouldn't accept media that the player can't actually play. Using AAC audio, 8K and 60 fps limits here.
     // AAC supports up to 96 channels.
-    if (parameters.channels > 96)
+    bool ok;
+    unsigned channels = parameters.type.parameter(ASCIILiteral("channels")).toUInt(&ok);
+    if (ok && channels > 96)
         return result;
+
+    float width = parameters.type.parameter(ASCIILiteral("width")).toFloat(&ok);
+    if (!ok)
+        width = 0;
+
+    float height = parameters.type.parameter(ASCIILiteral("height")).toFloat(&ok);
+    if (!ok)
+        height = 0;
 
     // 8K is up to 7680*4320
-    if (parameters.dimension.width() > 7680.0 || parameters.dimension.height() > 4320.0)
+    if (width > 7680.0 || height > 4320.0)
         return result;
 
-    if (parameters.framerate > 60.0)
+    float framerate = parameters.type.parameter(ASCIILiteral("framerate")).toFloat(&ok);
+    if (ok && framerate > 60.0)
         return result;
 
     // Spec says we should not return "probably" if the codecs string is empty.


### PR DESCRIPTION
This has been merged already in staging-emev3, see #382, but it would be nice to have it in master as well, since this helps reducing the diff with upstream.

Since r217905, the type member now contains the full ContentType.

This was introduced in commit 277e5de from @eocanha
[GStreamer][MSE] Reject too big channels/framerate/width/height mime type values

Also use ASCIILiteral() to build strings.