### PR TITLE
[GStreamer] Optimize the GstGL no color conversion case on WPE

### DIFF
--- a/Source/WebCore/platform/graphics/gstreamer/MediaPlayerPrivateGStreamerBase.cpp
+++ b/Source/WebCore/platform/graphics/gstreamer/MediaPlayerPrivateGStreamerBase.cpp
@@ -61,7 +61,11 @@
 #endif
 
 #if USE(GSTREAMER_GL)
-#if G_BYTE_ORDER == G_LITTLE_ENDIAN
+#if PLATFORM(WPE)
+#define GST_GL_CAPS_FORMAT "{ RGBA }"
+#define TEXTURE_MAPPER_COLOR_CONVERT_FLAG static_cast<TextureMapperGL::Flag>(0);
+#define TEXTURE_COPIER_COLOR_CONVERT_FLAG VideoTextureCopierGStreamer::ColorConversion::AlreadyRGBA
+#elif G_BYTE_ORDER == G_LITTLE_ENDIAN)
 #define GST_GL_CAPS_FORMAT "{ BGRx, BGRA }"
 #define TEXTURE_MAPPER_COLOR_CONVERT_FLAG TextureMapperGL::ShouldConvertTextureBGRAToRGBA
 #define TEXTURE_COPIER_COLOR_CONVERT_FLAG VideoTextureCopierGStreamer::ColorConversion::ConvertBGRAToRGBA

--- a/Source/WebCore/platform/graphics/gstreamer/VideoTextureCopierGStreamer.cpp
+++ b/Source/WebCore/platform/graphics/gstreamer/VideoTextureCopierGStreamer.cpp
@@ -75,6 +75,9 @@ VideoTextureCopierGStreamer::~VideoTextureCopierGStreamer()
 void VideoTextureCopierGStreamer::updateColorConversionMatrix(ColorConversion colorConversion)
 {
     switch (colorConversion) {
+    case ColorConversion::AlreadyRGBA:
+        m_colorConversionMatrix.setMatrix(1.0, 0.0, 0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0, 0.0, 1.0);
+        break;
     case ColorConversion::ConvertBGRAToRGBA:
         m_colorConversionMatrix.setMatrix(0.0, 0.0, 1.0, 0.0, 0.0, 1.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 1.0);
         break;

--- a/Source/WebCore/platform/graphics/gstreamer/VideoTextureCopierGStreamer.h
+++ b/Source/WebCore/platform/graphics/gstreamer/VideoTextureCopierGStreamer.h
@@ -35,6 +35,7 @@ class ImageOrientation;
 class VideoTextureCopierGStreamer {
 public:
     enum class ColorConversion {
+        AlreadyRGBA,
         ConvertBGRAToRGBA,
         ConvertARGBToRGBA
     };


### PR DESCRIPTION
There's some video stuttering since the last WPE merge from upstream. Its cause is that there's an RGBA --> BGRA color conversion in the GstGLColorConvertElement. This wasn't happening before.
This patch constrains the caps to RGBA only and avoids such conversion. The goal is to avoid it only on the Raspberry Pi, but Miguel suggested that it could be extrapolable to all WPE.