### PR TITLE
Fix debug build with legacy inspector server enabled

### DIFF
--- a/Source/WebKit/Platform/Logging.h
+++ b/Source/WebKit/Platform/Logging.h
@@ -47,6 +47,7 @@ extern "C" {
     M(Gamepad) \
     M(IconDatabase) \
     M(IndexedDB) \
+    M(InspectorServer) \
     M(IPC) \
     M(KeyHandling) \
     M(Layers) \


### PR DESCRIPTION
InspectorServer logging needs to be added back.