### PR TITLE
Take into account decryptor caps when calling trackDetected

### DIFF
--- a/Source/WebCore/platform/graphics/gstreamer/mse/AppendPipeline.cpp
+++ b/Source/WebCore/platform/graphics/gstreamer/mse/AppendPipeline.cpp
@@ -1264,9 +1264,18 @@ void AppendPipeline::connectDemuxerSrcPadToAppsink(GstPad* demuxerSrcPad)
         break;
     }
 
-    m_appsinkCaps = WTFMove(caps);
-    if (m_playerPrivate)
-        m_playerPrivate->trackDetected(this, m_track, true);
+#if ENABLE(ENCRYPTED_MEDIA)
+    // Don't try and guess the caps from the demuxer src right now, wait instead for the caps change
+    // when the decryptor transforms caps and call trackDetected after that event, see appsinkCapsChanged.
+    if (!m_decryptor) {
+#endif
+        m_appsinkCaps = WTFMove(caps);
+
+        if (m_playerPrivate)
+            m_playerPrivate->trackDetected(this, m_track, true);
+#if ENABLE(ENCRYPTED_MEDIA)
+    }
+#endif
 
     m_padAddRemoveCondition.notifyOne();
 }


### PR DESCRIPTION
The changes in 2b4b64b783676 were not taking into account that
parseDemuxerSrcPadCaps can insert a decryptor element into the pipeline after
the demuxer, this was causing trackDetected to try and interpret the sink caps
of the decyptor, rather than it's decrypted src caps.

* platform/graphics/gstreamer/mse/AppendPipeline.cpp:
(WebCore::AppendPipeline::connectDemuxerSrcPadToAppsink):