### PR TITLE
Fix GStreamer MediaPlayer build

### DIFF
--- a/Source/WebCore/platform/graphics/gstreamer/MediaPlayerPrivateGStreamerBase.h
+++ b/Source/WebCore/platform/graphics/gstreamer/MediaPlayerPrivateGStreamerBase.h
@@ -152,8 +152,8 @@ public:
     void attemptToDecryptWithLocalInstance();
     void attemptToDecryptWithInstance(const CDMInstance&) override;
 
-#if USE(OPENCDM)
     using InitData = String;
+#if USE(OPENCDM)
     void mapProtectionEventToInitData(const InitData&, GstEventSeqNum);
     void unmapProtectionEventFromInitData(GstEventSeqNum);
     virtual bool dispatchDecryptionSessionToPipeline(const String&, GstEventSeqNum);


### PR DESCRIPTION
Build was failing due to missing declaration of InitData.
This type was being declared only for OPENCDM, however it
was being referenced for other DRMs.