### PR TITLE
Remove deprecated libsoup network cache

### DIFF
--- a/Source/WebCore/platform/network/soup/SoupNetworkSession.cpp
+++ b/Source/WebCore/platform/network/soup/SoupNetworkSession.cpp
@@ -194,18 +194,6 @@ SoupCookieJar* SoupNetworkSession::cookieJar() const
     return SOUP_COOKIE_JAR(soup_session_get_feature(m_soupSession.get(), SOUP_TYPE_COOKIE_JAR));
 }
 
-void SoupNetworkSession::setCache(SoupCache* cache)
-{
-   ASSERT(!soup_session_get_feature(m_soupSession.get(), SOUP_TYPE_CACHE));
-   soup_session_add_feature(m_soupSession.get(), SOUP_SESSION_FEATURE(cache));
-}
-
-SoupCache* SoupNetworkSession::cache() const
-{
-    SoupSessionFeature* soupCache = soup_session_get_feature(m_soupSession.get(), SOUP_TYPE_CACHE);
-    return soupCache ? SOUP_CACHE(soupCache) : nullptr;
-}
-
 static inline bool stringIsNumeric(const char* str)
 {
     while (*str) {
@@ -216,7 +204,8 @@ static inline bool stringIsNumeric(const char* str)
     return true;
 }
 
-void SoupNetworkSession::clearCache(const String& cacheDirectory)
+// Old versions of WebKit created this cache.
+void SoupNetworkSession::clearOldSoupCache(const String& cacheDirectory)
 {
     CString cachePath = fileSystemRepresentation(cacheDirectory);
     GUniquePtr<char> cacheFile(g_build_filename(cachePath.data(), "soup.cache2", nullptr));

--- a/Source/WebCore/platform/network/soup/SoupNetworkSession.h
+++ b/Source/WebCore/platform/network/soup/SoupNetworkSession.h
@@ -56,9 +56,7 @@ public:
     void setCookieJar(SoupCookieJar*);
     SoupCookieJar* cookieJar() const;
 
-    void setCache(SoupCache*);
-    SoupCache* cache() const;
-    static void clearCache(const String& cacheDirectory);
+    static void clearOldSoupCache(const String& cacheDirectory);
 
 #if PLATFORM(WPE)
     static void setProxySettingsFromEnvironment();

--- a/Source/WebKit/NetworkProcess/soup/NetworkProcessSoup.cpp
+++ b/Source/WebKit/NetworkProcess/soup/NetworkProcessSoup.cpp
@@ -120,9 +120,9 @@ void NetworkProcess::platformInitializeNetworkProcess(const NetworkProcessCreati
     ASSERT(!parameters.diskCacheDirectory.isEmpty());
     m_diskCacheDirectory = parameters.diskCacheDirectory;
 
-#if ENABLE(NETWORK_CACHE)
-    SoupNetworkSession::clearCache(WebCore::directoryName(m_diskCacheDirectory));
+    SoupNetworkSession::clearOldSoupCache(WebCore::directoryName(m_diskCacheDirectory));
 
+#if ENABLE(NETWORK_CACHE)
     OptionSet<NetworkCache::Cache::Option> cacheOptions { NetworkCache::Cache::Option::RegisterNotify };
     if (parameters.shouldEnableNetworkCacheEfficacyLogging)
         cacheOptions |= NetworkCache::Cache::Option::EfficacyLogging;
@@ -132,19 +132,6 @@ void NetworkProcess::platformInitializeNetworkProcess(const NetworkProcessCreati
 #endif
 
     m_cache = NetworkCache::Cache::open(m_diskCacheDirectory, cacheOptions);
-#else
-    // We used to use the given cache directory for the soup cache, but now we use a subdirectory to avoid
-    // conflicts with other cache files in the same directory. Remove the old cache files if they still exist.
-    SoupNetworkSession::clearCache(WebCore::directoryName(m_diskCacheDirectory));
-
-    GRefPtr<SoupCache> soupCache = adoptGRef(soup_cache_new(m_diskCacheDirectory.utf8().data(), SOUP_CACHE_SINGLE_USER));
-    NetworkStorageSession::defaultStorageSession().getOrCreateSoupNetworkSession().setCache(soupCache.get());
-    // Set an initial huge max_size for the SoupCache so the call to soup_cache_load() won't evict any cached
-    // resource. The final size of the cache will be set by NetworkProcess::platformSetCacheModel().
-    unsigned initialMaxSize = soup_cache_get_max_size(soupCache.get());
-    soup_cache_set_max_size(soupCache.get(), G_MAXUINT);
-    soup_cache_load(soupCache.get());
-    soup_cache_set_max_size(soupCache.get(), initialMaxSize);
 #endif
 
     if (!parameters.cookiePersistentStoragePath.isEmpty()) {
@@ -159,13 +146,8 @@ void NetworkProcess::platformInitializeNetworkProcess(const NetworkProcessCreati
     setIgnoreTLSErrors(parameters.ignoreTLSErrors);
 }
 
-void NetworkProcess::platformSetURLCacheSize(unsigned /*urlCacheMemoryCapacity*/, uint64_t urlCacheDiskCapacity)
+void NetworkProcess::platformSetURLCacheSize(unsigned, uint64_t)
 {
-#if !ENABLE(NETWORK_CACHE)
-    soup_cache_set_max_size(NetworkStorageSession::defaultStorageSession().getOrCreateSoupNetworkSession().cache(), urlCacheDiskCapacity);
-#else
-    UNUSED_PARAM(urlCacheDiskCapacity);
-#endif
 }
 
 void NetworkProcess::setIgnoreTLSErrors(bool ignoreTLSErrors)
@@ -195,7 +177,6 @@ void NetworkProcess::clearDiskCache(std::chrono::system_clock::time_point modifi
 #else
     UNUSED_PARAM(modifiedSince);
     UNUSED_PARAM(completionHandler);
-    soup_cache_clear(NetworkStorageSession::defaultStorageSession().getOrCreateSoupNetworkSession().cache());
 #endif
 }
 


### PR DESCRIPTION
Sync code with upstream at fork revision r222498.

This codepath has been removed upstream in r205556 ([EFL] Switch to
ENABLE_NETWORK_CACHE), but was being pulled over through merges.

The libsoup cache is broken regarding partial HTTP requests: it would
reply the full content if present in cache.
This breaks the following YouTube 2017 MSE: AppendMultipleInitAACAudio,
AppendMultipleInitVP9Video and AppendMultipleInitH264Video.

The NETWORK_CACHE codepath has been enabled for the WK2 GTK port in r183865.

Also, the libsoup code was missing soup_cache_flush()/soup_cache_dump() calls
in NetworkProcessMain::platformFinalize(), which caused the cache not to be
saved at exit. This code has been removed upstream for GTK port in r192761.