### PR TITLE
Removed ".toDouble()" function calling from the line for fix the compilation error

### DIFF
--- a/Source/WebCore/platform/graphics/gstreamer/MediaPlayerPrivateGStreamer.cpp
+++ b/Source/WebCore/platform/graphics/gstreamer/MediaPlayerPrivateGStreamer.cpp
@@ -1819,7 +1819,7 @@ void MediaPlayerPrivateGStreamer::didEnd()
 
     if (!m_player->client().mediaPlayerIsLooping()) {
         m_paused = true;
-        m_durationAtEOS = durationMediaTime().toDouble();
+        m_durationAtEOS = durationMediaTime();
         changePipelineState(GST_STATE_READY);
         m_downloadFinished = false;
     }


### PR DESCRIPTION
```
Source/WebCore/platform/graphics/gstreamer/MediaPlayerPrivateGStreamer.cpp:1901:25: error: use of deleted function 'WTF::MediaTime::MediaTime(double)'
|          m_durationAtEOS = durationMediaTime().toDouble();
                           ^
```