### PR TITLE
Add API to set a limit of cookies

### DIFF
--- a/Source/WebCore/platform/network/NetworkStorageSession.h
+++ b/Source/WebCore/platform/network/NetworkStorageSession.h
@@ -108,6 +108,7 @@ public:
     void setCookieObserverHandler(Function<void ()>&&);
     void getCredentialFromPersistentStorage(const ProtectionSpace&, Function<void (Credential&&)> completionHandler);
     void saveCredentialToPersistentStorage(const ProtectionSpace&, const Credential&);
+    void setCookiesLimit(uint64_t limit);
 #else
     NetworkStorageSession(PAL::SessionID, NetworkingContext*);
     ~NetworkStorageSession();
@@ -135,6 +136,7 @@ private:
     mutable std::unique_ptr<SoupNetworkSession> m_session;
     GRefPtr<SoupCookieJar> m_cookieStorage;
     Function<void ()> m_cookieObserverHandler;
+    uint64_t m_cookiesLimit { 0 };
 #if USE(LIBSECRET)
     Function<void (Credential&&)> m_persisentStorageCompletionHandler;
     GRefPtr<GCancellable> m_persisentStorageCancellable;

--- a/Source/WebCore/platform/network/soup/NetworkStorageSessionSoup.cpp
+++ b/Source/WebCore/platform/network/soup/NetworkStorageSessionSoup.cpp
@@ -135,6 +135,7 @@ void NetworkStorageSession::setCookieStorage(SoupCookieJar* jar)
         m_cookieStorage = adoptGRef(soup_cookie_jar_new());
         soup_cookie_jar_set_accept_policy(m_cookieStorage.get(), SOUP_COOKIE_JAR_ACCEPT_NO_THIRD_PARTY);
     }
+    setCookiesLimit(m_cookiesLimit);
     g_signal_connect_swapped(m_cookieStorage.get(), "changed", G_CALLBACK(cookiesDidChange), this);
     if (m_session && m_session->cookieJar() != m_cookieStorage.get())
         m_session->setCookieJar(m_cookieStorage.get());
@@ -143,6 +144,12 @@ void NetworkStorageSession::setCookieStorage(SoupCookieJar* jar)
 void NetworkStorageSession::setCookieObserverHandler(Function<void ()>&& handler)
 {
     m_cookieObserverHandler = WTFMove(handler);
+}
+
+void NetworkStorageSession::setCookiesLimit(uint64_t limit)
+{
+    m_cookiesLimit = limit;
+    soup_cookie_jar_set_limit(m_cookieStorage.get(), m_cookiesLimit);
 }
 
 #if USE(LIBSECRET)

--- a/Source/WebKit/NetworkProcess/NetworkProcessCreationParameters.cpp
+++ b/Source/WebKit/NetworkProcess/NetworkProcessCreationParameters.cpp
@@ -91,6 +91,7 @@ void NetworkProcessCreationParameters::encode(IPC::Encoder& encoder) const
     encoder << cookiePersistentStoragePath;
     encoder << cookiePersistentStorageType;
     encoder.encodeEnum(cookieAcceptPolicy);
+    encoder << cookiesLimit;
     encoder << ignoreTLSErrors;
     encoder << languages;
     encoder << proxySettings;
@@ -191,6 +192,8 @@ bool NetworkProcessCreationParameters::decode(IPC::Decoder& decoder, NetworkProc
     if (!decoder.decode(result.cookiePersistentStorageType))
         return false;
     if (!decoder.decodeEnum(result.cookieAcceptPolicy))
+        return false;
+    if (!decoder.decode(result.cookiesLimit))
         return false;
     if (!decoder.decode(result.ignoreTLSErrors))
         return false;

--- a/Source/WebKit/NetworkProcess/NetworkProcessCreationParameters.h
+++ b/Source/WebKit/NetworkProcess/NetworkProcessCreationParameters.h
@@ -104,6 +104,7 @@ struct NetworkProcessCreationParameters {
     String cookiePersistentStoragePath;
     uint32_t cookiePersistentStorageType { 0 };
     HTTPCookieAcceptPolicy cookieAcceptPolicy { HTTPCookieAcceptPolicyAlways };
+    uint64_t cookiesLimit { 0 };
     bool ignoreTLSErrors { false };
     Vector<String> languages;
     WebCore::SoupNetworkProxySettings proxySettings;

--- a/Source/WebKit/NetworkProcess/soup/NetworkProcessSoup.cpp
+++ b/Source/WebKit/NetworkProcess/soup/NetworkProcessSoup.cpp
@@ -139,6 +139,7 @@ void NetworkProcess::platformInitializeNetworkProcess(const NetworkProcessCreati
             parameters.cookiePersistentStorageType);
     }
     supplement<WebCookieManager>()->setHTTPCookieAcceptPolicy(parameters.cookieAcceptPolicy, OptionalCallbackID());
+    supplement<WebCookieManager>()->setLimit(parameters.cookiesLimit);
 
     if (!parameters.languages.isEmpty())
         userPreferredLanguagesChanged(parameters.languages);

--- a/Source/WebKit/UIProcess/API/C/WKCookieManager.cpp
+++ b/Source/WebKit/UIProcess/API/C/WKCookieManager.cpp
@@ -109,3 +109,10 @@ void WKCookieManagerStopObservingCookieChanges(WKCookieManagerRef cookieManager)
 {
     toImpl(cookieManager)->stopObservingCookieChanges(PAL::SessionID::defaultSessionID());
 }
+
+void WKCookieManagerSetLimit(WKCookieManagerRef cookieManager, uint64_t limit)
+{
+#if USE(SOUP)
+    toImpl(cookieManager)->setLimit(limit);
+#endif
+}

--- a/Source/WebKit/UIProcess/API/C/WKCookieManager.h
+++ b/Source/WebKit/UIProcess/API/C/WKCookieManager.h
@@ -82,6 +82,8 @@ WK_EXPORT void WKCookieManagerGetCookies(WKCookieManagerRef cookieManager, void*
 WK_EXPORT void WKCookieManagerStartObservingCookieChanges(WKCookieManagerRef cookieManager);
 WK_EXPORT void WKCookieManagerStopObservingCookieChanges(WKCookieManagerRef cookieManager);
 
+WK_EXPORT void WKCookieManagerSetLimit(WKCookieManagerRef cookieManager, uint64_t limit);
+
 #ifdef __cplusplus
 }
 #endif

--- a/Source/WebKit/UIProcess/WebCookieManagerProxy.h
+++ b/Source/WebKit/UIProcess/WebCookieManagerProxy.h
@@ -103,6 +103,7 @@ public:
 #if USE(SOUP)
     void setCookiePersistentStorage(const String& storagePath, uint32_t storageType);
     void getCookiePersistentStorage(String& storagePath, uint32_t& storageType) const;
+    void setLimit(uint64_t limit);
 #endif
 
     using API::Object::ref;
@@ -145,6 +146,7 @@ private:
 #if USE(SOUP)
     String m_cookiePersistentStoragePath;
     SoupCookiePersistentStorageType m_cookiePersistentStorageType;
+    uint64_t m_cookieStorageLimit { 0 };
 #endif
 };
 

--- a/Source/WebKit/UIProcess/WebProcessPool.h
+++ b/Source/WebKit/UIProcess/WebProcessPool.h
@@ -230,6 +230,7 @@ public:
 #if USE(SOUP)
     void setInitialHTTPCookieAcceptPolicy(HTTPCookieAcceptPolicy policy) { m_initialHTTPCookieAcceptPolicy = policy; }
     void setNetworkProxySettings(const WebCore::SoupNetworkProxySettings&);
+    void setInitialCookiesLimit(uint64_t limit) { m_initialCookiesLimit = limit; }
 #endif
     void setEnhancedAccessibility(bool);
     
@@ -530,6 +531,7 @@ private:
 #if USE(SOUP)
     HTTPCookieAcceptPolicy m_initialHTTPCookieAcceptPolicy { HTTPCookieAcceptPolicyOnlyFromMainDocumentDomain };
     WebCore::SoupNetworkProxySettings m_networkProxySettings;
+    uint64_t m_initialCookiesLimit { 0 };
 #endif
     HashSet<String, ASCIICaseInsensitiveHash> m_urlSchemesRegisteredForCustomProtocols;
 

--- a/Source/WebKit/UIProcess/soup/WebCookieManagerProxySoup.cpp
+++ b/Source/WebKit/UIProcess/soup/WebCookieManagerProxySoup.cpp
@@ -44,4 +44,11 @@ void WebCookieManagerProxy::getCookiePersistentStorage(String& storagePath, uint
     storageType = static_cast<uint32_t>(m_cookiePersistentStorageType);
 }
 
+void WebCookieManagerProxy::setLimit(uint64_t limit)
+{
+    m_cookieStorageLimit = limit;
+    processPool()->setInitialCookiesLimit(limit);
+    processPool()->sendToNetworkingProcess(Messages::WebCookieManager::SetLimit(m_cookieStorageLimit));
+}
+
 }

--- a/Source/WebKit/UIProcess/soup/WebProcessPoolSoup.cpp
+++ b/Source/WebKit/UIProcess/soup/WebProcessPoolSoup.cpp
@@ -40,6 +40,7 @@ void WebProcessPool::platformInitializeNetworkProcess(NetworkProcessCreationPara
 {
     supplement<WebCookieManagerProxy>()->getCookiePersistentStorage(parameters.cookiePersistentStoragePath, parameters.cookiePersistentStorageType);
     parameters.cookieAcceptPolicy = m_initialHTTPCookieAcceptPolicy;
+    parameters.cookiesLimit = m_initialCookiesLimit;
     parameters.ignoreTLSErrors = m_ignoreTLSErrors;
     parameters.languages = userPreferredLanguages();
     for (const auto& scheme : m_urlSchemesRegisteredForCustomProtocols)

--- a/Source/WebKit/WebProcess/Cookies/WebCookieManager.h
+++ b/Source/WebKit/WebProcess/Cookies/WebCookieManager.h
@@ -61,6 +61,7 @@ public:
 
 #if USE(SOUP)
     void setCookiePersistentStorage(const String& storagePath, uint32_t storageType);
+    void setLimit(uint64_t limit);
 #endif
 
     void notifyCookiesDidChange(PAL::SessionID);

--- a/Source/WebKit/WebProcess/Cookies/WebCookieManager.messages.in
+++ b/Source/WebKit/WebProcess/Cookies/WebCookieManager.messages.in
@@ -46,5 +46,6 @@
 
 #if USE(SOUP)
     SetCookiePersistentStorage(String storagePath, uint32_t storageType)
+    SetLimit(uint64_t limit)
 #endif
 }

--- a/Source/WebKit/WebProcess/Cookies/soup/WebCookieManagerSoup.cpp
+++ b/Source/WebKit/WebProcess/Cookies/soup/WebCookieManagerSoup.cpp
@@ -91,4 +91,9 @@ void WebCookieManager::setCookiePersistentStorage(const String& storagePath, uin
     storageSession.setCookieStorage(jar.get());
 }
 
+void WebCookieManager::setLimit(uint64_t limit)
+{
+    NetworkStorageSession::defaultStorageSession().setCookiesLimit(limit);
+}
+
 } // namespace WebKit


### PR DESCRIPTION
Source/WebCore:
* platform/network/NetworkStorageSession.h:
* platform/network/soup/NetworkStorageSessionSoup.cpp:
(WebCore::NetworkStorageSession::setCookieStorage):
(WebCore::NetworkStorageSession::setCookiesLimit):

Source/WebKit:
* NetworkProcess/NetworkProcessCreationParameters.cpp:
(WebKit::NetworkProcessCreationParameters::encode const):
(WebKit::NetworkProcessCreationParameters::decode):
* NetworkProcess/NetworkProcessCreationParameters.h:
* NetworkProcess/soup/NetworkProcessSoup.cpp:
(WebKit::NetworkProcess::platformInitializeNetworkProcess):
* UIProcess/API/C/WKCookieManager.cpp:
(WKCookieManagerSetLimit):
* UIProcess/API/C/WKCookieManager.h:
* UIProcess/WebCookieManagerProxy.h:
* UIProcess/WebProcessPool.h:
* UIProcess/soup/WebCookieManagerProxySoup.cpp:
(WebKit::WebCookieManagerProxy::setLimit):
* UIProcess/soup/WebProcessPoolSoup.cpp:
(WebKit::WebProcessPool::platformInitializeNetworkProcess):
* WebProcess/Cookies/WebCookieManager.h:
* WebProcess/Cookies/WebCookieManager.messages.in:
* WebProcess/Cookies/soup/WebCookieManagerSoup.cpp:
(WebKit::WebCookieManager::setLimit):