### PR TITLE
[GStreamer] Fix video hole punching after layer recycling

### DIFF
--- a/Source/WebCore/platform/graphics/gstreamer/MediaPlayerPrivateGStreamerBase.cpp
+++ b/Source/WebCore/platform/graphics/gstreamer/MediaPlayerPrivateGStreamerBase.cpp
@@ -689,6 +689,10 @@ RefPtr<TextureMapperPlatformLayerProxy> MediaPlayerPrivateGStreamerBase::proxy()
 
 void MediaPlayerPrivateGStreamerBase::swapBuffersIfNeeded()
 {
+#if USE(HOLE_PUNCH_GSTREAMER) && USE(COORDINATED_GRAPHICS_THREADED)
+    LockHolder locker(m_platformLayerProxy->lock());
+    m_platformLayerProxy->pushNextBuffer(std::make_unique<TextureMapperPlatformLayerBuffer>(0, m_size, TextureMapperGL::ShouldOverwriteRect, GraphicsContext3D::DONT_CARE));
+#endif
 }
 
 void MediaPlayerPrivateGStreamerBase::pushTextureToCompositor()

--- a/Source/WebCore/platform/graphics/texmap/coordinated/CoordinatedGraphicsLayer.cpp
+++ b/Source/WebCore/platform/graphics/texmap/coordinated/CoordinatedGraphicsLayer.cpp
@@ -398,6 +398,8 @@ void CoordinatedGraphicsLayer::setContentsToPlatformLayer(PlatformLayer* platfor
         if (m_platformLayer)
             m_platformLayer->setClient(nullptr);
         m_shouldSyncPlatformLayer = true;
+        if (platformLayer)
+            m_shouldUpdatePlatformLayer = true;
     }
 
     m_platformLayer = platformLayer;


### PR DESCRIPTION
The issue is reproducible on YouTube:
 - start youtube app
 - play any video
 - press down and navigate to the search button
 - once in search page, press back
 - observe that the audio continues but video stops working.

Or by executing following in web inspector console
```
document.body.innerHTML = '';
var vid = document.createElement('video');
vid.src = 'https://yt-dash-mse-test.commondatastorage.googleapis.com/unit-tests/media/car_20130125_18.mp4';
document.body.appendChild(vid);

vid.play();

// wait for video playback to start, then
vid.pause();

// reattach video layer
document.body.innerHTML = '';
document.body.appendChild(vid);

// start playback again, expected to see the video
vid.play();
```
