### PR TITLE
Replace GraphicsContext3D::DONT_CARE with GL_DONT_CARE in MediaPlayer…

### DIFF
--- a/Source/WebCore/platform/graphics/holepunch/MediaPlayerPrivateHolePunchBase.cpp
+++ b/Source/WebCore/platform/graphics/holepunch/MediaPlayerPrivateHolePunchBase.cpp
@@ -47,7 +47,7 @@ MediaPlayerPrivateHolePunchBase::MediaPlayerPrivateHolePunchBase(MediaPlayer* pl
 #if USE(COORDINATED_GRAPHICS_THREADED)
     m_platformLayerProxy = adoptRef(new TextureMapperPlatformLayerProxy());
     LockHolder locker(m_platformLayerProxy->lock());
-    m_platformLayerProxy->pushNextBuffer(std::make_unique<TextureMapperPlatformLayerBuffer>(0, m_size, TextureMapperGL::ShouldOverwriteRect, GraphicsContext3D::DONT_CARE));
+    m_platformLayerProxy->pushNextBuffer(std::make_unique<TextureMapperPlatformLayerBuffer>(0, m_size, TextureMapperGL::ShouldOverwriteRect, GL_DONT_CARE));
 #endif
 }
 


### PR DESCRIPTION
…PrivateHolePunchBase

Since TextureMapperGL.h does not include GraphicsContext3D.h anymore, GraphicsContext3D::DONT_CARE should be replaced with GL_DONT_CARE in MediaPlayerPrivateHolePunchBase.cpp