### PR TITLE
[GStreamer] Stop pushing buffers when seeking status changes.

### DIFF
--- a/Source/WebCore/platform/graphics/gstreamer/WebKitWebSourceGStreamer.cpp
+++ b/Source/WebCore/platform/graphics/gstreamer/WebKitWebSourceGStreamer.cpp
@@ -976,31 +976,34 @@ void CachedResourceStreamingClient::dataReceived(PlatformMediaResource&, const c
     // to push buffers that are too large, otherwise incorrect buffering messages can be sent from the
     // pipeline.
     uint64_t bufferSize = gst_buffer_get_size(priv->buffer.get());
-    uint64_t blockSize = static_cast<uint64_t>(GST_BASE_SRC_CAST(priv->appsrc)->blocksize);
-    ASSERT(blockSize);
+    uint64_t blockSize = static_cast<uint64_t>(gst_base_src_get_blocksize(GST_BASE_SRC_CAST(priv->appsrc)));
     GST_LOG_OBJECT(src, "Splitting the received buffer into %" PRIu64 " blocks", bufferSize / blockSize);
+    // FIXME: Use GstBufferLists when we upgrade to 1.14.1 instead of pushing individual buffers.
     for (uint64_t currentOffset = 0; currentOffset < bufferSize; currentOffset += blockSize) {
         uint64_t subBufferOffset = startingOffset + currentOffset;
         uint64_t currentOffsetSize = std::min(blockSize, bufferSize - currentOffset);
 
         GST_TRACE_OBJECT(src, "Create sub-buffer from [%" PRIu64 ", %" PRIu64 "]", currentOffset, currentOffset + currentOffsetSize);
-        GstBuffer* subBuffer = gst_buffer_copy_region(priv->buffer.get(), GST_BUFFER_COPY_ALL, currentOffset, currentOffsetSize);
+        GRefPtr<GstBuffer> subBuffer = adoptGRef(gst_buffer_copy_region(priv->buffer.get(), GST_BUFFER_COPY_ALL, currentOffset, currentOffsetSize));
         if (UNLIKELY(!subBuffer)) {
             GST_ELEMENT_ERROR(src, CORE, FAILED, ("Failed to allocate sub-buffer"), (nullptr));
             break;
         }
 
-        GST_BUFFER_OFFSET(subBuffer) = subBufferOffset;
-        GST_BUFFER_OFFSET_END(subBuffer) = subBufferOffset + currentOffsetSize;
-        GST_TRACE_OBJECT(src, "Set sub-buffer offset bounds [%" PRIu64 ", %" PRIu64 "]", GST_BUFFER_OFFSET(subBuffer), GST_BUFFER_OFFSET_END(subBuffer));
+        GST_BUFFER_OFFSET(subBuffer.get()) = subBufferOffset;
+        GST_BUFFER_OFFSET_END(subBuffer.get()) = subBufferOffset + currentOffsetSize;
+        GST_TRACE_OBJECT(src, "Set sub-buffer offset bounds [%" PRIu64 ", %" PRIu64 "]", GST_BUFFER_OFFSET(subBuffer.get()), GST_BUFFER_OFFSET_END(subBuffer.get()));
 
-        GST_TRACE_OBJECT(src, "Pushing buffer of size %" G_GSIZE_FORMAT " bytes", gst_buffer_get_size(subBuffer));
-        GstFlowReturn ret = gst_app_src_push_buffer(priv->appsrc, subBuffer);
+        GST_TRACE_OBJECT(src, "Pushing buffer of size %" G_GSIZE_FORMAT " bytes", gst_buffer_get_size(subBuffer.get()));
+        GstFlowReturn ret = gst_app_src_push_buffer(priv->appsrc, subBuffer.leakRef());
 
-       if (UNLIKELY(ret != GST_FLOW_OK && ret != GST_FLOW_EOS && ret != GST_FLOW_FLUSHING)) {
+        if (UNLIKELY(ret != GST_FLOW_OK && ret != GST_FLOW_EOS && ret != GST_FLOW_FLUSHING)) {
             GST_ELEMENT_ERROR(src, CORE, FAILED, (nullptr), (nullptr));
             break;
         }
+
+        if (priv->isSeeking)
+            break;
     }
 
     priv->buffer.clear();

--- a/Source/WebCore/platform/graphics/gstreamer/WebKitWebSourceGStreamer.cpp
+++ b/Source/WebCore/platform/graphics/gstreamer/WebKitWebSourceGStreamer.cpp
@@ -975,13 +975,12 @@ void CachedResourceStreamingClient::dataReceived(PlatformMediaResource&, const c
     // Now split the recv'd buffer into buffers that are of a size basesrc suggests. It is important not
     // to push buffers that are too large, otherwise incorrect buffering messages can be sent from the
     // pipeline.
-    uint64_t bufferSize = gst_buffer_get_size(priv->buffer.get());
     uint64_t blockSize = static_cast<uint64_t>(gst_base_src_get_blocksize(GST_BASE_SRC_CAST(priv->appsrc)));
-    GST_LOG_OBJECT(src, "Splitting the received buffer into %" PRIu64 " blocks", bufferSize / blockSize);
+    GST_LOG_OBJECT(src, "Splitting the received buffer into %" PRIu64 " blocks", length / blockSize);
     // FIXME: Use GstBufferLists when we upgrade to 1.14.1 instead of pushing individual buffers.
-    for (uint64_t currentOffset = 0; currentOffset < bufferSize; currentOffset += blockSize) {
+    for (uint64_t currentOffset = 0; currentOffset < length; currentOffset += blockSize) {
         uint64_t subBufferOffset = startingOffset + currentOffset;
-        uint64_t currentOffsetSize = std::min(blockSize, bufferSize - currentOffset);
+        uint64_t currentOffsetSize = std::min(blockSize, length - currentOffset);
 
         GST_TRACE_OBJECT(src, "Create sub-buffer from [%" PRIu64 ", %" PRIu64 "]", currentOffset, currentOffset + currentOffsetSize);
         GRefPtr<GstBuffer> subBuffer = adoptGRef(gst_buffer_copy_region(priv->buffer.get(), GST_BUFFER_COPY_ALL, currentOffset, currentOffsetSize));


### PR DESCRIPTION
After switching to splitting buffers into smaller block sizes in

   https://bugs.webkit.org/show_bug.cgi?id=182829

It was found that during the individual buffer pushes, the seeking status could
change behind our backs from another thread. When this happens, buffers from
incorrect offsets would find their way into appsrc and eventually the demuxer
itself, which would start parsing from a random place and at best give a
confusing error message.

The solution here is break from pushing buffers when the seeking status has
been detected as changed. Flushes will clear out what we've already delivered
into the appsrc, just have to make sure to not continue sending buffers in
there after the flush.

* platform/graphics/gstreamer/WebKitWebSourceGStreamer.cpp:
(CachedResourceStreamingClient::dataReceived):