### PR TITLE
RenderLayerCompositor: fix crash because of missing return value

### DIFF
--- a/Source/WebCore/rendering/RenderLayerCompositor.cpp
+++ b/Source/WebCore/rendering/RenderLayerCompositor.cpp
@@ -2471,6 +2471,7 @@ bool RenderLayerCompositor::requiresCompositingForVideo(RenderLayerModelObject& 
         auto& video = downcast<RenderVideo>(renderer);
         return (video.requiresImmediateCompositing() || video.shouldDisplayVideo()) && canAccelerateVideoRendering(video);
     }
+    return false;
 #else
     UNUSED_PARAM(renderer);
     return false;


### PR DESCRIPTION
One code-path of requiresCompositingForVideo() did not return a value,
triggering an UDF instruction on ARM and SIGILL signal.