### PR TITLE
[2.38][GStreamer][WesterosQuirk] set low-latency-mode  property

### DIFF
--- a/Source/WebCore/platform/gstreamer/GStreamerQuirkWesteros.cpp
+++ b/Source/WebCore/platform/gstreamer/GStreamerQuirkWesteros.cpp
@@ -61,9 +61,14 @@ void GStreamerQuirkWesteros::configureElement(GstElement* element, const OptionS
     if (!characteristics.contains(ElementRuntimeCharacteristics::IsMediaStream))
         return;
 
-    if (!g_strcmp0(G_OBJECT_TYPE_NAME(G_OBJECT(element)), "GstWesterosSink") && gstObjectHasProperty(element, "immediate-output")) {
-        GST_INFO("Enable 'immediate-output' in WesterosSink");
-        g_object_set(element, "immediate-output", TRUE, nullptr);
+    if (!g_strcmp0(G_OBJECT_TYPE_NAME(G_OBJECT(element)), "GstWesterosSink")){
+        if(gstObjectHasProperty(element, "low-latency-mode")) {
+            GST_INFO("Enable 'low-latency-mode' in WesterosSink");
+            g_object_set(element, "low-latency-mode", TRUE, NULL);
+        } else if (gstObjectHasProperty(element, "immediate-output")) {
+            GST_INFO("Enable 'immediate-output' in WesterosSink");
+            g_object_set(element, "immediate-output", TRUE, NULL);
+        }
     }
 }
 

--- a/Source/WebCore/platform/gstreamer/GStreamerQuirkWesteros.cpp
+++ b/Source/WebCore/platform/gstreamer/GStreamerQuirkWesteros.cpp
@@ -64,10 +64,10 @@ void GStreamerQuirkWesteros::configureElement(GstElement* element, const OptionS
     if (!g_strcmp0(G_OBJECT_TYPE_NAME(G_OBJECT(element)), "GstWesterosSink")){
         if(gstObjectHasProperty(element, "low-latency-mode")) {
             GST_INFO("Enable 'low-latency-mode' in WesterosSink");
-            g_object_set(element, "low-latency-mode", TRUE, NULL);
+            g_object_set(element, "low-latency-mode", TRUE, nullptr);
         } else if (gstObjectHasProperty(element, "immediate-output")) {
             GST_INFO("Enable 'immediate-output' in WesterosSink");
-            g_object_set(element, "immediate-output", TRUE, NULL);
+            g_object_set(element, "immediate-output", TRUE, nullptr);
         }
     }
 }


### PR DESCRIPTION
Amlogic recently added "low-latency-mode" property to their Westeros sink. This property needs to be enabled to achieve the lowest latency when playing webRTC cloud gaming streams.
