### PR TITLE
[GStreamer][WesterosQuirk] set low-latency-mode  property

### DIFF
--- a/Source/WebCore/platform/gstreamer/GStreamerQuirkWesteros.cpp
+++ b/Source/WebCore/platform/gstreamer/GStreamerQuirkWesteros.cpp
@@ -85,9 +85,14 @@ void GStreamerQuirkWesteros::configureElement(GstElement* element, const OptionS
     if (!characteristics.contains(ElementRuntimeCharacteristics::IsMediaStream))
         return;
 
-    if (!g_strcmp0(G_OBJECT_TYPE_NAME(G_OBJECT(element)), "GstWesterosSink") && gstObjectHasProperty(element, "immediate-output")) {
-        GST_INFO("Enable 'immediate-output' in WesterosSink");
-        g_object_set(element, "immediate-output", TRUE, nullptr);
+    if (!g_strcmp0(G_OBJECT_TYPE_NAME(G_OBJECT(element)), "GstWesterosSink")){
+        if(gstObjectHasProperty(element, "low-latency-mode")) {
+            GST_INFO("Enable 'low-latency-mode' in WesterosSink");
+            g_object_set(element, "low-latency-mode", TRUE, nullptr);
+        } else if (gstObjectHasProperty(element, "immediate-output")) {
+            GST_INFO("Enable 'immediate-output' in WesterosSink");
+            g_object_set(element, "immediate-output", TRUE, nullptr);
+        }
     }
 }
 


### PR DESCRIPTION
Amlogic uses "low-latency-mode"  Westeros sink property instead of "immediate-mode" for lowest latency.<!--EWS-Status-Bubble-Start-->
https://github.com/WebPlatformForEmbedded/WPEWebKit/commit/bfbdaec0846d9a488ed74d792c3a98bb0a095596

| Build-Tests | Layout-Tests |
| ----------- | ------------ |
| | 
| | 
| [✅ 🛠 wpe-246-amd64-build](https://ews-wpe-rdk.igalia.com/#/builders/11/builds/187 "Built successfully") | [✅ 🧪 wpe-246-amd64-layout](https://ews-wpe-rdk.igalia.com/#/builders/9/builds/88 "Passed tests") 
| [✅ 🛠 wpe-246-arm32-build](https://ews-wpe-rdk.igalia.com/#/builders/12/builds/188 "Built successfully") | [❌ 🧪 wpe-246-arm32-layout](https://ews-wpe-rdk.igalia.com/#/builders/10/builds/90 "Found 1 new test failure: fast/sub-pixel/sub-pixel-composited-layers.html (failure)") 
<!--EWS-Status-Bubble-End-->