### PR TITLE
blinking images when decoding is async

### DIFF
--- a/LayoutTests/fast/images/async-image-background-change.html
+++ b/LayoutTests/fast/images/async-image-background-change.html
@@ -14,10 +14,10 @@
                 image.onload = (() => {
                     if (window.internals && window.testRunner && forceAsyncImageDrawing) {
                         // Force async image decoding for this image.
-                        internals.setLargeImageAsyncDecodingEnabledForTesting(image, true);
+                        internals.setAsyncDecodingEnabledForTesting(image, true);
 
                         image.addEventListener("webkitImageFrameReady", function() {
-                            internals.setLargeImageAsyncDecodingEnabledForTesting(image, false);
+                            internals.setAsyncDecodingEnabledForTesting(image, false);
                             setTimeout(function() {
                                 // Force redraw to get the red image drawn.
                                 testRunner.display();

--- a/LayoutTests/fast/images/async-image-background-image-repeated.html
+++ b/LayoutTests/fast/images/async-image-background-image-repeated.html
@@ -51,7 +51,7 @@
             image.onload = function() {
                  // Force async image decoding for this image.
                 if (window.internals)
-                    internals.setLargeImageAsyncDecodingEnabledForTesting(image, true);
+                    internals.setAsyncDecodingEnabledForTesting(image, true);
 
                 // Change the background of the elements.
                 var elements = document.getElementsByClassName("image-background");

--- a/LayoutTests/fast/images/async-image-background-image.html
+++ b/LayoutTests/fast/images/async-image-background-image.html
@@ -34,7 +34,7 @@
             image.onload = function() {
                 // Force async image decoding for this image.
                 if (window.internals)
-                    internals.setLargeImageAsyncDecodingEnabledForTesting(image, true);
+                    internals.setAsyncDecodingEnabledForTesting(image, true);
 
                 // Change the background of the element.                 
                 var element = document.getElementsByClassName("image-background")[0];

--- a/LayoutTests/fast/images/async-image-body-background-image.html
+++ b/LayoutTests/fast/images/async-image-body-background-image.html
@@ -37,7 +37,7 @@
             image.onload = function() {
                 // Force async image decoding for this image.
                 if (window.internals)
-                    internals.setLargeImageAsyncDecodingEnabledForTesting(image, true);
+                    internals.setAsyncDecodingEnabledForTesting(image, true);
 
                 var iframeDocument = document.querySelector('iframe').contentWindow.document;
 

--- a/LayoutTests/fast/images/async-image-multiple-clients-repaint.html
+++ b/LayoutTests/fast/images/async-image-multiple-clients-repaint.html
@@ -67,7 +67,7 @@
             image.onload = function() {
                 // Force async image decoding for this image.
                 if (window.internals)
-                    internals.setLargeImageAsyncDecodingEnabledForTesting(image, true);
+                    internals.setAsyncDecodingEnabledForTesting(image, true);
 
                 if (window.internals && window.testRunner) {
                     setElementImageBackground(document.querySelector(".small-box"), image).then(() => {

--- a/LayoutTests/fast/images/async-image-src-change.html
+++ b/LayoutTests/fast/images/async-image-src-change.html
@@ -7,7 +7,7 @@
                 image.onload = (() => {
                     if (window.internals && window.testRunner && forceAsyncImageDrawing) {
                         // Force async image decoding for this image.
-                        internals.setLargeImageAsyncDecodingEnabledForTesting(image, true);
+                        internals.setAsyncDecodingEnabledForTesting(image, true);
 
                         // Force layout and display so the image gets drawn.
                         document.body.offsetHeight;
@@ -15,7 +15,7 @@
                             testRunner.display();
 
                         image.addEventListener("webkitImageFrameReady", function() {
-                            internals.setLargeImageAsyncDecodingEnabledForTesting(image, false);
+                            internals.setAsyncDecodingEnabledForTesting(image, false);
                             setTimeout(function() {
                                 // Force redraw to get the red image drawn.
                                 testRunner.display();

--- a/LayoutTests/fast/images/decode-render-static-image.html
+++ b/LayoutTests/fast/images/decode-render-static-image.html
@@ -26,7 +26,7 @@
         image.onload = (() => {
             if (window.internals && window.testRunner) {
                 // Force async image decoding for this image.
-                internals.setLargeImageAsyncDecodingEnabledForTesting(image, true);
+                internals.setAsyncDecodingEnabledForTesting(image, true);
 
                 // Force layout and display so the image gets drawn.
                 document.body.offsetHeight;

--- a/LayoutTests/fast/images/decoding-attribute-async-small-image.html
+++ b/LayoutTests/fast/images/decoding-attribute-async-small-image.html
@@ -6,6 +6,9 @@
             return new Promise((resolve) => {
                 image.onload = (() => {
                     if (window.internals && window.testRunner) {
+                        // Force async image decoding for this image.
+                        internals.setAsyncDecodingEnabledForTesting(image, true);
+
                         // Force layout and display so the image gets drawn.
                         document.body.offsetHeight;
                         testRunner.display();

--- a/LayoutTests/fast/images/decoding-attribute-dynamic-async-small-image.html
+++ b/LayoutTests/fast/images/decoding-attribute-dynamic-async-small-image.html
@@ -6,6 +6,9 @@
             return new Promise((resolve) => {
                 image.onload = (() => {
                     if (window.internals && window.testRunner) {
+                        // Force async image decoding for this image.
+                        internals.setAsyncDecodingEnabledForTesting(image, true);
+
                         // Force layout and display so the image gets drawn.
                         document.body.offsetHeight;
                         testRunner.display();

--- a/LayoutTests/fast/images/sprite-sheet-image-draw.html
+++ b/LayoutTests/fast/images/sprite-sheet-image-draw.html
@@ -28,7 +28,7 @@
             image.onload = function() {
                 // Force async image decoding for this image.
                 if (window.internals)
-                    internals.setLargeImageAsyncDecodingEnabledForTesting(image, true);
+                    internals.setAsyncDecodingEnabledForTesting(image, true);
 
                 // Change the background of the element.
                 var element = document.getElementsByClassName("image-background")[0];

--- a/Source/WebCore/dom/Node.cpp
+++ b/Source/WebCore/dom/Node.cpp
@@ -1212,6 +1212,16 @@ HTMLSlotElement* Node::assignedSlotForBindings() const
     return nullptr;
 }
 
+bool Node::hasEverPaintedImages() const
+{
+    return hasRareData() && rareData()->hasEverPaintedImages();
+}
+
+void Node::setHasEverPaintedImages(bool hasEverPaintedImages)
+{
+    ensureRareData().setHasEverPaintedImages(hasEverPaintedImages);
+}
+
 ContainerNode* Node::parentInComposedTree() const
 {
     ASSERT(isMainThreadOrGCThread());

--- a/Source/WebCore/dom/Node.h
+++ b/Source/WebCore/dom/Node.h
@@ -247,6 +247,9 @@ public:
     HTMLSlotElement* assignedSlot() const;
     HTMLSlotElement* assignedSlotForBindings() const;
 
+    bool hasEverPaintedImages() const;
+    void setHasEverPaintedImages(bool);
+
     bool isUndefinedCustomElement() const { return customElementState() == CustomElementState::Undefined || customElementState() == CustomElementState::Failed; }
     bool isCustomElementUpgradeCandidate() const { return customElementState() == CustomElementState::Undefined; }
     bool isDefinedCustomElement() const { return customElementState() == CustomElementState::Custom; }

--- a/Source/WebCore/dom/NodeRareData.h
+++ b/Source/WebCore/dom/NodeRareData.h
@@ -295,6 +295,9 @@ public:
         return *m_mutationObserverData;
     }
 
+    bool hasEverPaintedImages() const { return m_hasEverPaintedImages; }
+    void setHasEverPaintedImages(bool hasEverPaintedImages) { m_hasEverPaintedImages = hasEverPaintedImages; }
+
 #if DUMP_NODE_STATISTICS
     OptionSet<UseType> useTypes() const
     {
@@ -314,6 +317,7 @@ protected:
 
 private:
     bool m_isElementRareData;
+    bool m_hasEverPaintedImages { false }; // Keep last for better bit packing with ElementRareData.
 
     std::unique_ptr<NodeListsNodeData> m_nodeLists;
     std::unique_ptr<NodeMutationObserverData> m_mutationObserverData;

--- a/Source/WebCore/loader/cache/CachedImage.h
+++ b/Source/WebCore/loader/cache/CachedImage.h
@@ -147,6 +147,7 @@ private:
         // ImageObserver API
         URL sourceUrl() const override { return !m_cachedImages.isEmpty() ? (*m_cachedImages.begin())->url() : URL(); }
         String mimeType() const override { return !m_cachedImages.isEmpty() ? (*m_cachedImages.begin())->mimeType() : emptyString(); }
+        unsigned numberOfClients() const override { return !m_cachedImages.isEmpty() ? (*m_cachedImages.begin())->numberOfClients() : 0; }
         long long expectedContentLength() const override { return !m_cachedImages.isEmpty() ? (*m_cachedImages.begin())->expectedContentLength() : 0; }
 
         void encodedDataStatusChanged(const Image&, EncodedDataStatus) final;

--- a/Source/WebCore/platform/graphics/BitmapImage.cpp
+++ b/Source/WebCore/platform/graphics/BitmapImage.cpp
@@ -86,6 +86,7 @@ void BitmapImage::destroyDecodedData(bool destroyAll)
     } else {
         m_source->destroyDecodedData(0, frameCount());
         m_currentFrameDecodingStatus = DecodingStatus::Invalid;
+        m_lastDecodingOptions = { DecodingMode::Auto };
     }
 
     // There's no need to throw away the decoder unless we're explicitly asked
@@ -257,6 +258,7 @@ ImageDrawResult BitmapImage::draw(GraphicsContext& context, const FloatRect& des
         // it is currently being decoded. New data may have been received since the previous request was made.
         if ((!frameIsCompatible && !frameIsBeingDecoded) || m_currentFrameDecodingStatus == DecodingStatus::Invalid) {
             LOG(Images, "BitmapImage::%s - %p - url: %s [requesting large async decoding]", __FUNCTION__, this, sourceURL().string().utf8().data());
+            m_lastDecodingOptions = { options.decodingMode() };
             m_source->requestFrameAsyncDecodingAtIndex(m_currentFrame, m_currentSubsamplingLevel, sizeForDrawing);
             m_currentFrameDecodingStatus = DecodingStatus::Decoding;
         }
@@ -300,6 +302,7 @@ ImageDrawResult BitmapImage::draw(GraphicsContext& context, const FloatRect& des
             }
             return ImageDrawResult::DidRequestDecoding;
         } else {
+            m_lastDecodingOptions = { options.decodingMode() };
             image = frameImageAtIndexCacheIfNeeded(m_currentFrame, m_currentSubsamplingLevel);
             LOG(Images, "BitmapImage::%s - %p - url: %s [an image frame will be decoded synchronously]", __FUNCTION__, this, sourceURL().string().utf8().data());
         }
@@ -664,6 +667,11 @@ DestinationColorSpace BitmapImage::colorSpace()
 unsigned BitmapImage::decodeCountForTesting() const
 {
     return m_decodeCountForTesting;
+}
+
+DecodingOptions BitmapImage::lastDecodingOptions() const
+{
+    return m_lastDecodingOptions;
 }
 
 void BitmapImage::dump(TextStream& ts) const

--- a/Source/WebCore/platform/graphics/BitmapImage.h
+++ b/Source/WebCore/platform/graphics/BitmapImage.h
@@ -118,8 +118,8 @@ public:
     bool canUseAsyncDecodingForLargeImages() const;
     bool shouldUseAsyncDecodingForAnimatedImages() const;
     void setClearDecoderAfterAsyncFrameRequestForTesting(bool value) { m_clearDecoderAfterAsyncFrameRequestForTesting = value; }
-    void setLargeImageAsyncDecodingEnabledForTesting(bool enabled) { m_largeImageAsyncDecodingEnabledForTesting = enabled; }
-    bool isLargeImageAsyncDecodingEnabledForTesting() const { return m_largeImageAsyncDecodingEnabledForTesting; }
+    void setAsyncDecodingEnabledForTesting(bool enabled) { m_asyncDecodingEnabledForTesting = enabled; }
+    bool isAsyncDecodingEnabledForTesting() const { return m_asyncDecodingEnabledForTesting; }
     void stopAsyncDecodingQueue() { m_source->stopAsyncDecodingQueue(); }
 
     DestinationColorSpace colorSpace() final;
@@ -249,7 +249,7 @@ private:
     bool m_showDebugBackground { false };
 
     bool m_clearDecoderAfterAsyncFrameRequestForTesting { false };
-    bool m_largeImageAsyncDecodingEnabledForTesting { false };
+    bool m_asyncDecodingEnabledForTesting { false };
 
 #if ASSERT_ENABLED || !LOG_DISABLED
     size_t m_lateFrameCount { 0 };

--- a/Source/WebCore/platform/graphics/BitmapImage.h
+++ b/Source/WebCore/platform/graphics/BitmapImage.h
@@ -158,6 +158,7 @@ public:
 
     void imageFrameAvailableAtIndex(size_t);
     void decode(Function<void()>&&);
+    WEBCORE_EXPORT DecodingOptions lastDecodingOptions() const;
 
 private:
     WEBCORE_EXPORT BitmapImage(Ref<NativeImage>&&);
@@ -258,6 +259,7 @@ private:
 #endif
 
     unsigned m_decodeCountForTesting { 0 };
+    DecodingOptions m_lastDecodingOptions { DecodingMode::Auto };
 
 #if USE(APPKIT)
     mutable RetainPtr<NSImage> m_nsImage; // A cached NSImage of all the frames. Only built lazily if someone actually queries for one.

--- a/Source/WebCore/platform/graphics/DecodingOptions.h
+++ b/Source/WebCore/platform/graphics/DecodingOptions.h
@@ -40,7 +40,7 @@ enum class DecodingMode : uint8_t {
 
 class DecodingOptions {
 public:
-    explicit DecodingOptions(DecodingMode decodingMode = DecodingMode::Auto)
+    DecodingOptions(DecodingMode decodingMode = DecodingMode::Auto)
         : m_decodingModeOrSize(decodingMode)
     {
     }

--- a/Source/WebCore/platform/graphics/ImageObserver.h
+++ b/Source/WebCore/platform/graphics/ImageObserver.h
@@ -41,6 +41,7 @@ protected:
 public:
     virtual URL sourceUrl() const = 0;
     virtual String mimeType() const = 0;
+    virtual unsigned numberOfClients() const { return 0; }
     virtual long long expectedContentLength() const = 0;
 
     virtual void encodedDataStatusChanged(const Image&, EncodedDataStatus) { };

--- a/Source/WebCore/rendering/RenderBoxModelObject.cpp
+++ b/Source/WebCore/rendering/RenderBoxModelObject.cpp
@@ -306,32 +306,58 @@ DecodingMode RenderBoxModelObject::decodingModeForImageDraw(const Image& image, 
         return DecodingMode::Synchronous;
     }
 
-    // Large image case.
+    // Some document types force synchronous decoding.
 #if PLATFORM(IOS_FAMILY)
     if (IOSApplication::isIBooksStorytime())
         return DecodingMode::Synchronous;
 #endif
-    if (is<HTMLImageElement>(element())) {
-        auto decodingMode = downcast<HTMLImageElement>(*element()).decodingMode();
-        if (decodingMode != DecodingMode::Auto)
-            return decodingMode;
-    }
-    if (bitmapImage.isLargeImageAsyncDecodingEnabledForTesting())
-        return DecodingMode::Asynchronous;
     if (document().isImageDocument())
         return DecodingMode::Synchronous;
+    if (!settings().largeImageAsyncDecodingEnabled())
+
+    // A PaintBehavior may force synchronous decoding.
     if (paintInfo.paintBehavior.contains(PaintBehavior::Snapshotting))
         return DecodingMode::Synchronous;
-    if (!settings().largeImageAsyncDecodingEnabled())
-        return DecodingMode::Synchronous;
-    if (!bitmapImage.canUseAsyncDecodingForLargeImages())
-        return DecodingMode::Synchronous;
-    if (paintInfo.paintBehavior.contains(PaintBehavior::TileFirstPaint))
+
+    auto defaultDecodingMode = [&]() -> DecodingMode {
+        // First tile paint.
+        if (paintInfo.paintBehavior.contains(PaintBehavior::TileFirstPaint)) {
+            // And the images has not been painted in this element yet.
+            if (element() && !element()->hasEverPaintedImages())
+                return DecodingMode::Asynchronous;
+        }
+
+        // FIXME: Calling isVisibleInViewport() is not cheap. Find a way to make this faster.
+        return isVisibleInViewport() ? DecodingMode::Synchronous : DecodingMode::Asynchronous;
+    };
+
+    if (is<HTMLImageElement>(element())) {
+        // <img decoding="sync"> forces synchronous decoding.
+        if (downcast<HTMLImageElement>(*element()).decodingMode() == DecodingMode::Synchronous)
+            return DecodingMode::Synchronous;
+
+        // <img decoding="async"> forces asynchronous decoding but make sure this
+        // will not cause flickering.
+        if (downcast<HTMLImageElement>(*element()).decodingMode() == DecodingMode::Asynchronous) {
+            // isAsyncDecodingEnabledForTesting() forces async image decoding regardless whether it is in the viewport or not.
+            if (bitmapImage.isAsyncDecodingEnabledForTesting())
+                return DecodingMode::Asynchronous;
+
+            // Choose a decodingMode such that the image does not flicker.
+            return defaultDecodingMode();
+        }
+    }
+
+    // isAsyncDecodingEnabledForTesting() forces async image decoding regardless of the size.
+    if (bitmapImage.isAsyncDecodingEnabledForTesting())
         return DecodingMode::Asynchronous;
-    // FIXME: isVisibleInViewport() is not cheap. Find a way to make this condition faster.
-    if (!isVisibleInViewport())
-        return DecodingMode::Asynchronous;
-    return DecodingMode::Synchronous;
+
+    // Large image case.
+    if (!(bitmapImage.canUseAsyncDecodingForLargeImages() && settings().largeImageAsyncDecodingEnabled()))
+        return DecodingMode::Synchronous;
+
+    // Choose a decodingMode such that the image does not flicker.
+    return defaultDecodingMode();
 }
 
 LayoutSize RenderBoxModelObject::relativePositionOffset() const

--- a/Source/WebCore/rendering/RenderBoxModelObject.cpp
+++ b/Source/WebCore/rendering/RenderBoxModelObject.cpp
@@ -322,8 +322,10 @@ DecodingMode RenderBoxModelObject::decodingModeForImageDraw(const Image& image, 
     auto defaultDecodingMode = [&]() -> DecodingMode {
         // First tile paint.
         if (paintInfo.paintBehavior.contains(PaintBehavior::TileFirstPaint)) {
-            // And the images has not been painted in this element yet.
-            if (element() && !element()->hasEverPaintedImages())
+            // No image has been painted in this element yet and it should not flicker with previous painting.
+            auto observer = bitmapImage.imageObserver();
+            bool mayOverlapOtherClients = observer && observer->numberOfClients() > 1 && bitmapImage.lastDecodingOptions().isAsynchronous();
+            if (element() && !element()->hasEverPaintedImages() && !mayOverlapOtherClients)
                 return DecodingMode::Asynchronous;
         }
 

--- a/Source/WebCore/rendering/RenderImage.cpp
+++ b/Source/WebCore/rendering/RenderImage.cpp
@@ -706,6 +706,9 @@ ImageDrawResult RenderImage::paintIntoRect(PaintInfo& paintInfo, const FloatRect
         theme().paintSystemPreviewBadge(*img, paintInfo, rect);
 #endif
 
+    if (element() && !paintInfo.context().paintingDisabled())
+        element()->setHasEverPaintedImages(true);
+
     return drawResult;
 }
 

--- a/Source/WebCore/rendering/RenderObject.h
+++ b/Source/WebCore/rendering/RenderObject.h
@@ -934,8 +934,8 @@ private:
 
     private:
         unsigned m_positionedState : 2; // PositionedState
-        unsigned m_selectionState : 3; // SelectionState
-        unsigned m_fragmentedFlowState : 2; // FragmentedFlowState
+        unsigned m_selectionState : 3; // HighlightState
+        unsigned m_fragmentedFlowState : 1; // FragmentedFlowState
         unsigned m_boxDecorationState : 2; // BoxDecorationState
 
     public:

--- a/Source/WebCore/testing/Internals.cpp
+++ b/Source/WebCore/testing/Internals.cpp
@@ -1087,10 +1087,10 @@ unsigned Internals::remoteImagesCountForTesting() const
     return document->page()->chrome().client().remoteImagesCountForTesting();
 }
 
-void Internals::setLargeImageAsyncDecodingEnabledForTesting(HTMLImageElement& element, bool enabled)
+void Internals::setAsyncDecodingEnabledForTesting(HTMLImageElement& element, bool enabled)
 {
     if (auto* bitmapImage = bitmapImageFromImageElement(element))
-        bitmapImage->setLargeImageAsyncDecodingEnabledForTesting(enabled);
+        bitmapImage->setAsyncDecodingEnabledForTesting(enabled);
 }
     
 void Internals::setForceUpdateImageDataEnabledForTesting(HTMLImageElement& element, bool enabled)

--- a/Source/WebCore/testing/Internals.h
+++ b/Source/WebCore/testing/Internals.h
@@ -224,7 +224,7 @@ public:
     unsigned imageDecodeCount(HTMLImageElement&);
     unsigned pdfDocumentCachingCount(HTMLImageElement&);
     unsigned remoteImagesCountForTesting() const;
-    void setLargeImageAsyncDecodingEnabledForTesting(HTMLImageElement&, bool enabled);
+    void setAsyncDecodingEnabledForTesting(HTMLImageElement&, bool enabled);
     void setForceUpdateImageDataEnabledForTesting(HTMLImageElement&, bool enabled);
 
     void setGridMaxTracksLimit(unsigned);

--- a/Source/WebCore/testing/Internals.idl
+++ b/Source/WebCore/testing/Internals.idl
@@ -558,7 +558,7 @@ typedef (FetchRequest or FetchResponse) FetchObject;
     unsigned long imageDecodeCount(HTMLImageElement element);
     unsigned long pdfDocumentCachingCount(HTMLImageElement element);
     unsigned long remoteImagesCountForTesting();
-    undefined setLargeImageAsyncDecodingEnabledForTesting(HTMLImageElement element, boolean enabled);
+    undefined setAsyncDecodingEnabledForTesting(HTMLImageElement element, boolean enabled);
     undefined setForceUpdateImageDataEnabledForTesting(HTMLImageElement element, boolean enabled);
 
     undefined setGridMaxTracksLimit(unsigned long maxTracksLimit);


### PR DESCRIPTION
posters blink when loading and navigating through https://astro.zee5.com/

two changes were introduced on wpe-2.46 which do cover the problem. in this PR those changes were rebased and augmented (a little) to work on wpe-2.38. base changes:

* https://github.com/WebPlatformForEmbedded/WPEWebKit/commit/8f042c727b90676c0a4f2910e26f4474ff08f6d2
* https://github.com/WebPlatformForEmbedded/WPEWebKit/commit/238ec677929193ee5fa48b504a09fdce55633145
<!--EWS-Status-Bubble-Start-->
https://github.com/WebPlatformForEmbedded/WPEWebKit/commit/28315962eb721238b5bd94aac87dd0d0994a0ef5

| Build-Tests | Layout-Tests |
| ----------- | ------------ |
| [✅ 🛠 wpe-238-amd64-build](https://ews-wpe-rdk.igalia.com/#/builders/1/builds/224 "Built successfully") | [✅ 🧪 wpe-238-amd64-layout](https://ews-wpe-rdk.igalia.com/#/builders/5/builds/93 "Passed tests") 
| [✅ 🛠 wpe-238-arm32-build](https://ews-wpe-rdk.igalia.com/#/builders/8/builds/222 "Built successfully") | [✅ 🧪 wpe-238-arm32-layout](https://ews-wpe-rdk.igalia.com/#/builders/6/builds/102 "Passed tests") 
| | 
| | 
<!--EWS-Status-Bubble-End-->