### PR TITLE
[MediaCapabilities] Protect MediaCapabilities JS wrapper from GC

### DIFF
--- a/Source/WebCore/Modules/mediacapabilities/MediaCapabilities.cpp
+++ b/Source/WebCore/Modules/mediacapabilities/MediaCapabilities.cpp
@@ -42,10 +42,21 @@
 #include "Page.h"
 #include "Settings.h"
 #include "WebRTCProvider.h"
+#include "NavigatorBase.h"
 #include <wtf/Logger.h>
 #include <wtf/SortedArrayMap.h>
 
 namespace WebCore {
+
+MediaCapabilities::MediaCapabilities(NavigatorBase& navigator)
+    : m_navigator(navigator)
+{
+}
+
+NavigatorBase* MediaCapabilities::navigator()
+{
+    return m_navigator.get();
+}
 
 static bool isValidMediaMIMEType(const ContentType& contentType)
 {

--- a/Source/WebCore/Modules/mediacapabilities/MediaCapabilities.h
+++ b/Source/WebCore/Modules/mediacapabilities/MediaCapabilities.h
@@ -33,18 +33,22 @@
 namespace WebCore {
 
 class DeferredPromise;
+class NavigatorBase;
 class ScriptExecutionContext;
 
 class MediaCapabilities : public RefCounted<MediaCapabilities>, public CanMakeWeakPtr<MediaCapabilities> {
 public:
-    static Ref<MediaCapabilities> create() { return adoptRef(*new MediaCapabilities); }
+    static Ref<MediaCapabilities> create(NavigatorBase& navigator) { return adoptRef(*new MediaCapabilities(navigator)); }
+
+    NavigatorBase* navigator();
 
     void decodingInfo(ScriptExecutionContext&, MediaDecodingConfiguration&&, Ref<DeferredPromise>&&);
     void encodingInfo(ScriptExecutionContext&, MediaEncodingConfiguration&&, Ref<DeferredPromise>&&);
 
 private:
-    MediaCapabilities() = default;
+    explicit MediaCapabilities(NavigatorBase&);
 
+    WeakPtr<NavigatorBase> m_navigator;
     uint64_t m_nextTaskIdentifier { 0 };
     HashMap<uint64_t, MediaEngineConfigurationFactory::DecodingConfigurationCallback> m_decodingTasks;
     HashMap<uint64_t, MediaEngineConfigurationFactory::EncodingConfigurationCallback> m_encodingTasks;

--- a/Source/WebCore/Modules/mediacapabilities/MediaCapabilities.idl
+++ b/Source/WebCore/Modules/mediacapabilities/MediaCapabilities.idl
@@ -25,7 +25,8 @@
 
 [
     EnabledBySetting=MediaCapabilitiesEnabled,
-    Exposed=(Window,DedicatedWorker)
+    Exposed=(Window,DedicatedWorker),
+    GenerateIsReachable=ReachableFromNavigator
 ] interface MediaCapabilities {
     [CallWith=CurrentScriptExecutionContext] Promise<MediaCapabilitiesDecodingInfo> decodingInfo(MediaDecodingConfiguration configuration);
     [CallWith=CurrentScriptExecutionContext] Promise<MediaCapabilitiesEncodingInfo> encodingInfo(MediaEncodingConfiguration configuration);

--- a/Source/WebCore/Modules/mediacapabilities/NavigatorMediaCapabilities.cpp
+++ b/Source/WebCore/Modules/mediacapabilities/NavigatorMediaCapabilities.cpp
@@ -31,8 +31,8 @@
 
 namespace WebCore {
 
-NavigatorMediaCapabilities::NavigatorMediaCapabilities()
-    : m_mediaCapabilities(MediaCapabilities::create())
+NavigatorMediaCapabilities::NavigatorMediaCapabilities(Navigator& navigator)
+    : m_mediaCapabilities(MediaCapabilities::create(navigator))
 {
 }
 
@@ -47,7 +47,7 @@ NavigatorMediaCapabilities& NavigatorMediaCapabilities::from(Navigator& navigato
 {
     NavigatorMediaCapabilities* supplement = static_cast<NavigatorMediaCapabilities*>(Supplement<Navigator>::from(&navigator, supplementName()));
     if (!supplement) {
-        auto newSupplement = makeUnique<NavigatorMediaCapabilities>();
+        auto newSupplement = makeUnique<NavigatorMediaCapabilities>(navigator);
         supplement = newSupplement.get();
         provideTo(&navigator, supplementName(), WTFMove(newSupplement));
     }

--- a/Source/WebCore/Modules/mediacapabilities/NavigatorMediaCapabilities.h
+++ b/Source/WebCore/Modules/mediacapabilities/NavigatorMediaCapabilities.h
@@ -35,7 +35,7 @@ class Navigator;
 class NavigatorMediaCapabilities final : public Supplement<Navigator> {
     WTF_MAKE_FAST_ALLOCATED;
 public:
-    NavigatorMediaCapabilities();
+    explicit NavigatorMediaCapabilities(Navigator&);
     ~NavigatorMediaCapabilities();
 
     static MediaCapabilities& mediaCapabilities(Navigator&);

--- a/Source/WebCore/Modules/mediacapabilities/WorkerNavigatorMediaCapabilities.cpp
+++ b/Source/WebCore/Modules/mediacapabilities/WorkerNavigatorMediaCapabilities.cpp
@@ -31,8 +31,8 @@
 
 namespace WebCore {
 
-WorkerNavigatorMediaCapabilities::WorkerNavigatorMediaCapabilities()
-    : m_mediaCapabilities(MediaCapabilities::create())
+WorkerNavigatorMediaCapabilities::WorkerNavigatorMediaCapabilities(WorkerNavigator& navigator)
+    : m_mediaCapabilities(MediaCapabilities::create(navigator))
 {
 }
 
@@ -47,7 +47,7 @@ WorkerNavigatorMediaCapabilities& WorkerNavigatorMediaCapabilities::from(WorkerN
 {
     auto* supplement = static_cast<WorkerNavigatorMediaCapabilities*>(Supplement<WorkerNavigator>::from(&navigator, supplementName()));
     if (!supplement) {
-        auto newSupplement = makeUnique<WorkerNavigatorMediaCapabilities>();
+        auto newSupplement = makeUnique<WorkerNavigatorMediaCapabilities>(navigator);
         supplement = newSupplement.get();
         provideTo(&navigator, supplementName(), WTFMove(newSupplement));
     }

--- a/Source/WebCore/Modules/mediacapabilities/WorkerNavigatorMediaCapabilities.h
+++ b/Source/WebCore/Modules/mediacapabilities/WorkerNavigatorMediaCapabilities.h
@@ -35,7 +35,7 @@ class WorkerNavigator;
 class WorkerNavigatorMediaCapabilities final : public Supplement<WorkerNavigator> {
     WTF_MAKE_FAST_ALLOCATED;
 public:
-    WorkerNavigatorMediaCapabilities();
+    explicit WorkerNavigatorMediaCapabilities(WorkerNavigator&);
     ~WorkerNavigatorMediaCapabilities();
 
     static MediaCapabilities& mediaCapabilities(WorkerNavigator&);


### PR DESCRIPTION
Add GenerateIsReachable=ReachableFromNavigator to prevent wrapper GC. The MediaCapabilities interface is annotated [SameObject] in the spec, meaning navigator.mediaCapabilities must return the same object on every access. Without GC protection, the JS wrapper can be collected when no JS reference holds it, causing a new wrapper to be created on next access. This breaks object identity and loses any user-set properties.

This fixes an issue with ShakaPlayer that sets its own, custom navigator.mediaCapabilities.decodingInfo wrapper JS function that provides DRM data in addition to native decodingInfo impl.
See https://github.com/shaka-project/shaka-player/blob/ce7ee4b76f1fd6104519fe6f20fe7dda9d759eaf/lib/polyfill/mcap_encryption_scheme.js#L131

<!--EWS-Status-Bubble-Start-->
https://github.com/WebPlatformForEmbedded/WPEWebKit/commit/53edfff6e5a4e96ac617aee1530559be4c26958d

| Build-Tests | Layout-Tests |
| ----------- | ------------ |
| | 
| | 
| [✅ 🛠 wpe-246-amd64-build](https://ews-wpe-rdk.igalia.com/#/builders/11/builds/236 "Built successfully") | [✅ 🧪 wpe-246-amd64-layout](https://ews-wpe-rdk.igalia.com/#/builders/9/builds/103 "Passed tests") 
| [✅ 🛠 wpe-246-arm32-build](https://ews-wpe-rdk.igalia.com/#/builders/12/builds/236 "Built successfully") | [✅ 🧪 wpe-246-arm32-layout](https://ews-wpe-rdk.igalia.com/#/builders/10/builds/107 "Passed tests") 
<!--EWS-Status-Bubble-End-->