### PR TITLE
[GTK][WPE] Add webkit_feature_list_find() to the API

### DIFF
--- a/Source/WebKit/UIProcess/API/glib/WebKitFeature.cpp
+++ b/Source/WebKit/UIProcess/API/glib/WebKitFeature.cpp
@@ -431,3 +431,27 @@ WebKitFeature* webkit_feature_list_get(WebKitFeatureList* featureList, gsize ind
     g_return_val_if_fail(index < featureList->items.size(), nullptr);
     return featureList->items[index];
 }
+
+/**
+ * webkit_feature_list_find:
+ * @feature_list: a #WebKitFeatureList
+ * @identifier: a #WebKitFeature identifier
+ *
+ * Finds a feature given its identifier.
+ *
+ * Returns: (transfer none) (nullable): The feature with the given
+ *     @identifier, or @NULL if it cannot be found.
+ *
+ * Since: 2.54
+ */
+WebKitFeature* webkit_feature_list_find(WebKitFeatureList* featureList, const char* identifier)
+{
+    g_return_val_if_fail(featureList, nullptr);
+    g_return_val_if_fail(identifier, nullptr);
+
+    auto it = std::ranges::find_if(featureList->items, [identifier](WebKitFeature* feature) -> bool {
+        return !g_ascii_strcasecmp(identifier, webkit_feature_get_identifier(feature));
+    });
+
+    return (it != featureList->items.end()) ? *it : nullptr;
+}

--- a/Source/WebKit/UIProcess/API/glib/WebKitFeature.h.in
+++ b/Source/WebKit/UIProcess/API/glib/WebKitFeature.h.in
@@ -124,6 +124,10 @@ WEBKIT_API WebKitFeature *
 webkit_feature_list_get          (WebKitFeatureList *feature_list,
                                   gsize              index);
 
+WEBKIT_API WebKitFeature *
+webkit_feature_list_find         (WebKitFeatureList *feature_list,
+                                  const gchar       *identifier);
+
 G_DEFINE_AUTOPTR_CLEANUP_FUNC(WebKitFeatureList, webkit_feature_list_unref)
 
 G_END_DECLS

--- a/Tools/MiniBrowser/gtk/main.c
+++ b/Tools/MiniBrowser/gtk/main.c
@@ -257,16 +257,6 @@ static gboolean isValidParameterType(GType gParamType)
             || gParamType == G_TYPE_FLOAT);
 }
 
-static WebKitFeature* findFeature(WebKitFeatureList *featureList, const char *identifier)
-{
-    for (gsize i = 0; i < webkit_feature_list_get_length(featureList); i++) {
-        WebKitFeature *feature = webkit_feature_list_get(featureList, i);
-        if (!g_ascii_strcasecmp(identifier, webkit_feature_get_identifier(feature)))
-            return feature;
-    }
-    return NULL;
-}
-
 static gboolean parseFeaturesOptionCallback(const gchar *option, const gchar *value, WebKitSettings *webSettings, GError **error)
 {
     g_autoptr(WebKitFeatureList) featureList = webkit_settings_get_all_features();
@@ -311,7 +301,7 @@ static gboolean parseFeaturesOptionCallback(const gchar *option, const gchar *va
             return FALSE;
         }
 
-        WebKitFeature *feature = findFeature(featureList, item);
+        WebKitFeature *feature = webkit_feature_list_find(featureList, item);
         if (!feature) {
             g_set_error(error, G_OPTION_ERROR, G_OPTION_ERROR_FAILED, "Feature '%s' is not available", item);
             return FALSE;

--- a/Tools/MiniBrowser/wpe/main.cpp
+++ b/Tools/MiniBrowser/wpe/main.cpp
@@ -373,16 +373,6 @@ static void automationStartedCallback(WebKitWebContext*, WebKitAutomationSession
     g_signal_connect(session, "create-web-view", G_CALLBACK(createWebViewForAutomationCallback), view);
 }
 
-static WebKitFeature* findFeature(WebKitFeatureList* featureList, const char* identifier)
-{
-    for (gsize i = 0; i < webkit_feature_list_get_length(featureList); i++) {
-        WebKitFeature* feature = webkit_feature_list_get(featureList, i);
-        if (!g_ascii_strcasecmp(identifier, webkit_feature_get_identifier(feature)))
-            return feature;
-    }
-    return nullptr;
-}
-
 static void activate(GApplication* application, WPEToolingBackends::ViewBackend* backend)
 {
     g_application_hold(application);
@@ -507,7 +497,7 @@ static void activate(GApplication* application, WPEToolingBackends::ViewBackend*
                 continue;
             }
 
-            if (auto* feature = findFeature(features, item))
+            if (auto* feature = webkit_feature_list_find(features, item))
                 webkit_settings_set_feature_enabled(settings, feature, enabled);
             else
                 g_printerr("Feature '%s' is not available.", item);

--- a/Tools/TestWebKitAPI/Tests/WebKitGLib/TestWebKitSettings.cpp
+++ b/Tools/TestWebKitAPI/Tests/WebKitGLib/TestWebKitSettings.cpp
@@ -493,6 +493,22 @@ void testWebKitFeatures(Test* test, gconstpointer)
 
         g_assert(webkit_settings_get_feature_enabled(settings.get(), feature) == webkit_feature_get_default_value(feature));
     }
+
+    // Check finding features given their identifier.
+    if (webkit_feature_list_get_length(allFeatures)) {
+        WebKitFeature* firstFeature = webkit_feature_list_get(allFeatures, 0);
+        WebKitFeature* foundFeature = webkit_feature_list_find(allFeatures, webkit_feature_get_identifier(firstFeature));
+        g_assert_nonnull(foundFeature);
+        g_assert(firstFeature == foundFeature);
+
+        g_autofree char* lowerCaseIdentifier = g_utf8_strdown(webkit_feature_get_identifier(firstFeature), -1);
+        foundFeature = webkit_feature_list_find(allFeatures, lowerCaseIdentifier);
+        g_assert_nonnull(foundFeature);
+        g_assert(firstFeature == foundFeature);
+    }
+
+    WebKitFeature* foundFeature = webkit_feature_list_find(allFeatures, "ThisFeatureIdentifierCannotPossiblyExist");
+    g_assert_null(foundFeature);
 }
 
 void testWebKitSettingsApplyFromConfigFile(Test* test, gconstpointer)


### PR DESCRIPTION
https://bugs.webkit.org/show_bug.cgi?id=307069

Reviewed by Michael Catanzaro and Patrick Griffis.

Add a convenience function to find a WebKitFeature from a given WebKitFeatureList. This will avoid code repetition in different projects.

* Source/WebKit/UIProcess/API/glib/WebKitFeature.cpp: (webkit_feature_list_find):
* Source/WebKit/UIProcess/API/glib/WebKitFeature.h.in:
* Tools/MiniBrowser/gtk/main.c: (parseFeaturesOptionCallback):
(findFeature): Deleted. Replaced with webkit_feature_list_find().
* Tools/MiniBrowser/wpe/main.cpp: (activate):
(findFeature): Deleted. Replaced with webkit_feature_list_find().
* Tools/TestWebKitAPI/Tests/WebKitGLib/TestWebKitSettings.cpp: (testWebKitFeatures): Add a few test cases for the new function.

Canonical link: https://commits.webkit.org/307348@main<!--EWS-Status-Bubble-Start-->
https://github.com/WebPlatformForEmbedded/WPEWebKit/commit/85fd7ef8449fef5d8af8a05126a8f2b3a816d06c

| Build-Tests | Layout-Tests |
| ----------- | ------------ |
| | 
| | 
| [✅ 🛠 wpe-246-amd64-build](https://ews-wpe-rdk.igalia.com/#/builders/11/builds/269 "Built successfully") | [✅ 🧪 wpe-246-amd64-layout](https://ews-wpe-rdk.igalia.com/#/builders/9/builds/121 "Passed tests") 
| [✅ 🛠 wpe-246-arm32-build](https://ews-wpe-rdk.igalia.com/#/builders/12/builds/269 "Built successfully") | [✅ 🧪 wpe-246-arm32-layout](https://ews-wpe-rdk.igalia.com/#/builders/10/builds/125 "Passed tests") 
<!--EWS-Status-Bubble-End-->