### PR TITLE
Fix readPIDFromPeer crash when child dies during launch

### DIFF
--- a/Source/WebKit/Platform/IPC/unix/ConnectionUnix.cpp
+++ b/Source/WebKit/Platform/IPC/unix/ConnectionUnix.cpp
@@ -647,6 +647,11 @@ pid_t readPIDFromPeer(int socket)
     if (ret == -1)
         g_error("readPIDFromPeer: Failed to read pid from PID socket: %s", g_strerror(errno));
 
+    if (ret == 0) {
+        // Peer died before sending PID (e.g. SIGTERM during container teardown).
+        return 0;
+    }
+
     if (message.msg_controllen <= 0)
         g_error("readPIDFromPeer: Unexpected short read from PID socket");
 

--- a/Source/WebKit/UIProcess/Launcher/glib/ProcessLauncherGLib.cpp
+++ b/Source/WebKit/UIProcess/Launcher/glib/ProcessLauncherGLib.cpp
@@ -258,7 +258,13 @@ void ProcessLauncher::launchProcess()
             g_error("Failed to read pid from child process");
 
         m_processID = IPC::readPIDFromPeer(g_socket_get_fd(pidSocket.get()));
-        RELEASE_ASSERT(m_processID);
+        if (!m_processID) {
+            m_socketMonitor.stop();
+            close(m_pidServerSocket);
+            m_pidServerSocket = -1;
+            didFinishLaunchingProcess(0, IPC::Connection::Identifier { });
+            return G_SOURCE_REMOVE;
+        }
 
         m_socketMonitor.stop();
 


### PR DESCRIPTION

When a child process (WPEWebProcess) is killed before sending its PID —
e.g. by SIGTERM during container teardown — recvmsg() returns 0 (EOF).
Previously this fell through to g_error("Unexpected short read") which
called abort(), crashing the parent.

readPIDFromPeer now returns 0 on EOF. When it returns 0, the launch
callback calls didFinishLaunchingProcess(0, IPC::Connection::Identifier{}),
which flows into WebProcessProxy::processDidTerminateOrFailedToLaunch(
ProcessTerminationReason::Crash) — the same crash notification path that
fires when a running WebProcess dies. Pages get notified, crash handling
kicks in, no abort. The socket monitor is then removed cleanly.

* Source/WebKit/Platform/IPC/unix/ConnectionUnix.cpp:
(IPC::readPIDFromPeer):
* Source/WebKit/UIProcess/Launcher/glib/ProcessLauncherGLib.cpp:
(WebKit::ProcessLauncher::launchProcess):<!--EWS-Status-Bubble-Start-->
https://github.com/WebPlatformForEmbedded/WPEWebKit/commit/c5a0bc4d6f4e737be7763adb032188bfece17e2f

| Build-Tests | Layout-Tests |
| ----------- | ------------ |
| | 
| | 
| [✅ 🛠 wpe-246-amd64-build](https://ews-wpe-rdk.igalia.com/#/builders/11/builds/286 "Built successfully") | [✅ 🧪 wpe-246-amd64-layout](https://ews-wpe-rdk.igalia.com/#/builders/9/builds/134 "Passed tests") 
| [✅ 🛠 wpe-246-arm32-build](https://ews-wpe-rdk.igalia.com/#/builders/12/builds/286 "Built successfully") | [❌ 🧪 wpe-246-arm32-layout](https://ews-wpe-rdk.igalia.com/#/builders/10/builds/139 "Found 1 new test failure: imported/w3c/web-platform-tests/html/browsers/the-window-object/open-close/open-features-tokenization-noopener.html (failure)") 
<!--EWS-Status-Bubble-End-->