### PR TITLE
Disable scheduled navigation while prov load is in progress

### DIFF
--- a/Source/WebCore/loader/NavigationScheduler.cpp
+++ b/Source/WebCore/loader/NavigationScheduler.cpp
@@ -589,6 +589,8 @@ void NavigationScheduler::timerFired()
         InspectorInstrumentation::frameClearedScheduledNavigation(m_frame);
         return;
     }
+    if (m_frame.loader().provisionalDocumentLoader())
+        return;
 
     Ref<Frame> protect(m_frame);
 


### PR DESCRIPTION
Issue description: 
While playing Fireplace web app (https://com-metrological-app-fireplace.cdn.prod.apps.dmdsdp.com/apps/6e0191fb-af4b-4b75-b9fd-cb6aa7602fd0/), if BBC iPlayer app (https://www.live.bbctvapps.co.uk/tap/iplayer) is launched, many a times the bbc iplayer app is not launched. Same issue seen when transitioning from Fireplace app to AppleTV or TV France app.

Analysis:
It is seen that when fireplace is launched, it triggers a scheduled navigation. Then when bbc iplayer is launched, the scheduled navigation timer of fireplace triggers and it causes the bbc iplayer provisional load to cancel.

Solution:
When a scheduled navigation timer triggers, ignore the navigation if a provisional load is in progress.


<!--EWS-Status-Bubble-Start-->
https://github.com/WebPlatformForEmbedded/WPEWebKit/commit/3b4305616dfc34cbab1f73a44810ea4f2e586013

| Build-Tests | Layout-Tests |
| ----------- | ------------ |
| [✅ 🛠 wpe-238-amd64-build](https://ews-wpe-rdk.igalia.com/#/builders/1/builds/278 "Built successfully") | [❌ 🧪 wpe-238-amd64-layout](https://ews-wpe-rdk.igalia.com/#/builders/5/builds/101 "Found 2 new test failures: http/tests/misc/timer-vs-loading.html, imported/w3c/web-platform-tests/html/browsers/browsing-the-web/navigating-across-documents/002.html (failure)") 
| [✅ 🛠 wpe-238-arm32-build](https://ews-wpe-rdk.igalia.com/#/builders/8/builds/277 "Built successfully") | [❌ 🧪 wpe-238-arm32-layout](https://ews-wpe-rdk.igalia.com/#/builders/6/builds/110 "Found 2 new test failures: http/tests/misc/timer-vs-loading.html, imported/w3c/web-platform-tests/html/browsers/browsing-the-web/navigating-across-documents/002.html (failure)") 
| | 
| | 
<!--EWS-Status-Bubble-End-->