### PR TITLE
Querying robustnesslevel from CDM instead of hardcoding the levels.

### DIFF
--- a/Source/WebCore/platform/GStreamer.cmake
+++ b/Source/WebCore/platform/GStreamer.cmake
@@ -175,6 +175,13 @@ if (ENABLE_ENCRYPTED_MEDIA AND ENABLE_THUNDER)
     # Globally add thunder libraries, required for the check_cxx_symbol_exists call.
     set(CMAKE_REQUIRED_LIBRARIES ${THUNDER_LIBRARIES})
 
+    check_cxx_symbol_exists(opencdm_system_supported_robustness ${THUNDER_INCLUDE_DIR}/open_cdm.h HAS_OCDM_SUPPORTED_ROBUSTNESS)
+    if (HAS_OCDM_SUPPORTED_ROBUSTNESS)
+      list(APPEND WebCore_PRIVATE_DEFINITIONS THUNDER_HAS_OCDM_SUPPORTED_ROBUSTNESS=1)
+    else ()
+      list(APPEND WebCore_PRIVATE_DEFINITIONS THUNDER_HAS_OCDM_SUPPORTED_ROBUSTNESS=0)
+    endif ()
+
     check_cxx_symbol_exists(opencdm_gstreamer_session_decrypt_buffer ${THUNDER_INCLUDE_DIR}/open_cdm_adapter.h HAS_OCDM_DECRYPT_BUFFER)
     if (HAS_OCDM_DECRYPT_BUFFER)
       list(APPEND WebCore_PRIVATE_DEFINITIONS THUNDER_HAS_OCDM_DECRYPT_BUFFER=1)

--- a/Source/WebCore/platform/graphics/gstreamer/eme/CDMThunder.cpp
+++ b/Source/WebCore/platform/graphics/gstreamer/eme/CDMThunder.cpp
@@ -171,38 +171,39 @@ bool CDMPrivateThunder::supportsConfiguration(const CDMKeySystemConfiguration& c
 
 Vector<AtomString> CDMPrivateThunder::supportedRobustnesses() const
 {
+    static const Vector<AtomString> defaultRobustnesses = { emptyAtom(), "SW_SECURE_DECODE"_s, "SW_SECURE_CRYPTO"_s };
+
 #if THUNDER_HAS_OCDM_SUPPORTED_ROBUSTNESS
-    Vector<AtomString> robustnesses = { emptyAtom() };
-    
     if (!m_thunderSystem) {
-        GST_ERROR("CDMPrivateThunder: No active OpenCDM system for %s. Returning default robustness only.", m_keySystem.utf8().data());
-        return robustnesses;
+        GST_WARNING("CDMPrivateThunder: No active OpenCDM system. Falling back to default WebKit robustness levels.");
+        return defaultRobustnesses;
     }
 
+    Vector<AtomString> robustnesses = { emptyAtom() };
     char** buffer = nullptr;
     uint16_t count = 0;
 
     OpenCDMError error = opencdm_system_supported_robustness(m_thunderSystem.get(), &buffer, &count);
-    if (error == ERROR_NONE && buffer != nullptr && count > 0) {
-        robustnesses.reserveCapacity(robustnesses.size() + count);
+    if (buffer) {
+        if (error == ERROR_NONE && count > 0)
+            robustnesses.reserveCapacity(robustnesses.size() + count);
+
         for (uint16_t i = 0; i < count; ++i) {
-            if (buffer[i] != nullptr) {
-                robustnesses.append(AtomString::fromLatin1(buffer[i]));;
-                free(buffer[i]);
-            }
+            if (error == ERROR_NONE && buffer[i])
+                robustnesses.append(AtomString::fromLatin1(buffer[i]));
+ 
+            free(buffer[i]);
         }
-    }
-    if (buffer != nullptr) {
         free(buffer);
     }
- 
-    if (error == ERROR_NONE && count > 0) {
+
+    if (error == ERROR_NONE && robustnesses.size() > 1)
         return robustnesses;
-    }
+
     GST_WARNING("Failed to get robustness levels from OCDM.Falling back to default WebKit robustness levels.");
 #endif
 
-    return { emptyAtom(), "SW_SECURE_DECODE"_s, "SW_SECURE_CRYPTO"_s };
+    return defaultRobustnesses;
 }
 
 CDMRequirement CDMPrivateThunder::distinctiveIdentifiersRequirement(const CDMKeySystemConfiguration&, const CDMRestrictions&) const

--- a/Source/WebCore/platform/graphics/gstreamer/eme/CDMThunder.cpp
+++ b/Source/WebCore/platform/graphics/gstreamer/eme/CDMThunder.cpp
@@ -171,6 +171,37 @@ bool CDMPrivateThunder::supportsConfiguration(const CDMKeySystemConfiguration& c
 
 Vector<AtomString> CDMPrivateThunder::supportedRobustnesses() const
 {
+#if THUNDER_HAS_OCDM_SUPPORTED_ROBUSTNESS
+    Vector<AtomString> robustnesses = { emptyAtom() };
+    
+    if (!m_thunderSystem) {
+        GST_ERROR("CDMPrivateThunder: No active OpenCDM system for %s. Returning default robustness only.", m_keySystem.utf8().data());
+        return robustnesses;
+    }
+
+    char** buffer = nullptr;
+    uint16_t count = 0;
+
+    OpenCDMError error = opencdm_system_supported_robustness(m_thunderSystem.get(), &buffer, &count);
+    if (error == ERROR_NONE && buffer != nullptr && count > 0) {
+        robustnesses.reserveCapacity(robustnesses.size() + count);
+        for (uint16_t i = 0; i < count; ++i) {
+            if (buffer[i] != nullptr) {
+                robustnesses.append(AtomString::fromLatin1(buffer[i]));;
+                free(buffer[i]);
+            }
+        }
+    }
+    if (buffer != nullptr) {
+        free(buffer);
+    }
+ 
+    if (error == ERROR_NONE && count > 0) {
+        return robustnesses;
+    }
+    GST_WARNING("Failed to get robustness levels from OCDM.Falling back to default WebKit robustness levels.");
+#endif
+
     return { emptyAtom(), "SW_SECURE_DECODE"_s, "SW_SECURE_CRYPTO"_s };
 }
 


### PR DESCRIPTION
Query robustnesslevel from CDM instead of hardcoding the levels.<!--EWS-Status-Bubble-Start-->
https://github.com/WebPlatformForEmbedded/WPEWebKit/commit/bd41d2f1a37c44f0c0ac8cdd0ede39509938e721

| Build-Tests | Layout-Tests |
| ----------- | ------------ |
| | 
| | 
| [✅ 🛠 wpe-246-amd64-build](https://ews-wpe-rdk.igalia.com/#/builders/11/builds/309 "Built successfully") | [✅ 🧪 wpe-246-amd64-layout](https://ews-wpe-rdk.igalia.com/#/builders/9/builds/149 "Passed tests") 
| [✅ 🛠 wpe-246-arm32-build](https://ews-wpe-rdk.igalia.com/#/builders/12/builds/309 "Built successfully") | [✅ 🧪 wpe-246-arm32-layout](https://ews-wpe-rdk.igalia.com/#/builders/10/builds/153 "Passed tests") 
<!--EWS-Status-Bubble-End-->