### PR TITLE
Backport of recent upstream EME crash fixes to wpe-2.46

### DIFF
--- a/LayoutTests/media/encrypted-media/mock-MediaKeySession-backforwardcache-prune-crash-expected.txt
+++ b/LayoutTests/media/encrypted-media/mock-MediaKeySession-backforwardcache-prune-crash-expected.txt
@@ -1,0 +1,1 @@
+PASS: pruning a back/forward-cached MediaKeySession page does not crash.

--- a/LayoutTests/media/encrypted-media/mock-MediaKeySession-backforwardcache-prune-crash.html
+++ b/LayoutTests/media/encrypted-media/mock-MediaKeySession-backforwardcache-prune-crash.html
@@ -1,0 +1,87 @@
+<!-- webkit-test-runner [ UsesBackForwardCache=true ] -->
+<!DOCTYPE html>
+<html>
+<head>
+<script>
+// Regression test: pruning a back/forward-cached page that still owns an open MediaKeySession must not crash.
+//
+// When the page enters the BackForwardCache its active DOM objects are suspended and its event-loop task group is
+// suspended. If the cached page is then pruned (rather than restored), Document teardown stops the active DOM
+// objects: markAsReadyToStop() runs first and -- because the group was suspended -- transitions it straight to
+// Stopped, while activeDOMObjectsAreSuspended() stays true. MediaKeySession::stop() then closes the CDM session;
+// the Thunder/Mock backends invoke the close callback synchronously, so before the fix sessionClosed() resolved
+// the "closed" promise synchronously here, tripping DeferredPromise's suspended-context assertion.
+//
+// This page opens a MediaKeySession and navigates to a helper so this document enters the BackForwardCache (the
+// proven page-cache navigation idiom -- a separate document, not a same-URL query change). The helper then prunes
+// the cache, which destroys this still-cached document. The result is reported by the helper, since this page is
+// gone by then.
+
+if (window.testRunner) {
+    testRunner.dumpAsText();
+    testRunner.waitUntilDone();
+}
+
+const encoder = new TextEncoder();
+
+async function setUpOpenSession() {
+    // Mirror the working mock-EME setup (mock-MediaKeySession-close.html): enable the mock media engine first or
+    // "video/mock" is unsupported and requestMediaKeySystemAccess rejects.
+    internals.initializeMockMediaSource();
+    // Pin the factory on window: CDMFactory's registry holds only a WeakRef, MockCDM holds only a WeakPtr,
+    // so the JS wrapper is the only strong reference. A local would let GC collect it across the awaits below,
+    // unregistering the factory mid-flight -- the failure presents as NotSupportedError or NotAllowedError
+    // depending on which await GC interleaves with.
+    window.__mock = internals.registerMockCDM();
+    window.__mock.supportedDataTypes = ["keyids"];
+
+    const access = await navigator.requestMediaKeySystemAccess("org.webkit.mock", [{
+        initDataTypes: ["keyids"],
+        videoCapabilities: [{ contentType: 'video/mock; codecs="mock"' }],
+    }]);
+    const mediaKeys = await access.createMediaKeys();
+    const session = mediaKeys.createSession("temporary");
+
+    // Keep both alive on the window so the session survives un-closed into the BackForwardCache; that is what makes
+    // MediaKeySession::stop() run against a suspended-then-stopped context when the cached page is pruned.
+    window.__mediaKeys = mediaKeys;
+    window.__session = session;
+
+    await session.generateRequest("keyids", encoder.encode(JSON.stringify({ kids: ["MTIzNDU="] })));
+
+    // Touch the "closed" attribute so a DeferredPromise is registered on its DOMPromiseProxy (real EME apps do
+    // `session.closed.then(...)`). Without an attached deferred promise, resolving the closed promise during
+    // teardown is a no-op that never reaches DeferredPromise::callFunction -- so the assertion would not fire and
+    // the test would pass even on the buggy build.
+    window.__closed = session.closed;
+}
+
+window.addEventListener("load", () => {
+    if (!window.internals || !window.testRunner) {
+        document.body.textContent = "FAIL: this test requires window.internals and window.testRunner.";
+        if (window.testRunner)
+            testRunner.notifyDone();
+        return;
+    }
+
+    setUpOpenSession().then(() => {
+        // Navigate outside the load/promise continuation so it produces a history entry.
+        setTimeout(() => { window.location.href = "resources/mock-MediaKeySession-backforwardcache-prune-helper.html"; }, 0);
+    }, e => {
+        document.body.textContent = "FAIL: could not set up MediaKeySession: " + e;
+        testRunner.notifyDone();
+    });
+});
+</script>
+</head>
+<body>
+<!-- Substantial visible content so the main frame is "visually non-empty"; canCachePage refuses a visually-empty
+     main frame, which would stop the page entering the cache at all. -->
+<div style="width: 400px; height: 400px;">
+This page opens an EME MediaKeySession and then navigates to a helper so that this document enters the back/forward
+cache. The helper prunes the cache, destroying this still-cached document while its MediaKeySession is open, which
+is the teardown path the fix is about. This paragraph exists so the page is visually non-empty and therefore
+eligible for the back/forward cache in the first place.
+</div>
+</body>
+</html>

--- a/LayoutTests/media/encrypted-media/mock-MediaKeySession-concurrent-close-expected.txt
+++ b/LayoutTests/media/encrypted-media/mock-MediaKeySession-concurrent-close-expected.txt
@@ -1,0 +1,19 @@
+RUN(internals.initializeMockMediaSource())
+RUN(mock = internals.registerMockCDM())
+RUN(mock.supportedDataTypes = ["keyids"])
+RUN(capabilities.initDataTypes = ["keyids"])
+RUN(capabilities.videoCapabilities = [{ contentType: 'video/mock; codecs="mock"' }] )
+RUN(promise = navigator.requestMediaKeySystemAccess("org.webkit.mock", [capabilities]))
+Promise resolved OK
+RUN(promise = mediaKeySystemAccess.createMediaKeys())
+Promise resolved OK
+RUN(kids = JSON.stringify({ kids: [ "MTIzNDU=" ] }))
+RUN(mediaKeySession = mediaKeys.createSession("temporary"))
+RUN(promise = mediaKeySession.generateRequest("keyids", encoder.encode(kids)))
+Promise resolved OK
+Two concurrent close() calls should both resolve without crashing.
+RUN(promise = mediaKeySession.close())
+RUN(promise2 = mediaKeySession.close())
+Survived concurrent close() and the "closed" promise resolved exactly once.
+END OF TEST
+

--- a/LayoutTests/media/encrypted-media/mock-MediaKeySession-concurrent-close.html
+++ b/LayoutTests/media/encrypted-media/mock-MediaKeySession-concurrent-close.html
@@ -1,0 +1,67 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <script src=../video-test.js></script>
+    <script type="text/javascript">
+    // Regression test: two concurrent close() calls on the same MediaKeySession must not resolve the
+    // "closed" promise twice. Each close() checks m_closed before queuing its work, but m_closed is only
+    // set when the queued task runs, so both calls queue a sessionClosed() task; resolving the "closed"
+    // promise a second time previously tripped an assertion in DOMPromiseProxy::resolve().
+    var mock;
+    var promise;
+    var promise2;
+    var mediaKeySystemAccess;
+    var mediaKeys;
+    var mediaKeySession;
+    var capabilities = {};
+    var kids;
+    var encoder = new TextEncoder();
+
+    function doTest()
+    {
+        if (!window.internals) {
+            failTest("Internals is required for this test.");
+            return;
+        }
+
+        run('internals.initializeMockMediaSource()');
+        run('mock = internals.registerMockCDM()');
+        run('mock.supportedDataTypes = ["keyids"]');
+        run('capabilities.initDataTypes = ["keyids"]');
+        run(`capabilities.videoCapabilities = [{ contentType: 'video/mock; codecs="mock"' }] `);
+        run('promise = navigator.requestMediaKeySystemAccess("org.webkit.mock", [capabilities])');
+        shouldResolve(promise).then(gotMediaKeySystemAccess, failTest);
+    }
+
+    function gotMediaKeySystemAccess(result) {
+        mediaKeySystemAccess = result;
+        run('promise = mediaKeySystemAccess.createMediaKeys()');
+        shouldResolve(promise).then(gotMediaKeys, failTest);
+    }
+
+    function gotMediaKeys(result) {
+        mediaKeys = result;
+        run('kids = JSON.stringify({ kids: [ "MTIzNDU=" ] })');
+        run('mediaKeySession = mediaKeys.createSession("temporary")');
+        run('promise = mediaKeySession.generateRequest("keyids", encoder.encode(kids))');
+        shouldResolve(promise).then(closeConcurrently, failTest);
+    }
+
+    function closeConcurrently() {
+        consoleWrite('Two concurrent close() calls should both resolve without crashing.');
+        run('promise = mediaKeySession.close()');
+        run('promise2 = mediaKeySession.close()');
+        // Wait on the raw promises (no per-promise logging) so completion order does not affect the output.
+        Promise.all([promise, promise2, mediaKeySession.closed]).then(finish, failTest);
+    }
+
+    function finish() {
+        consoleWrite('Survived concurrent close() and the "closed" promise resolved exactly once.');
+        mock.unregister();
+        endTest();
+    }
+    </script>
+</head>
+<body onload="doTest()">
+</body>
+</html>

--- a/LayoutTests/media/encrypted-media/resources/mock-MediaKeySession-backforwardcache-prune-helper.html
+++ b/LayoutTests/media/encrypted-media/resources/mock-MediaKeySession-backforwardcache-prune-helper.html
@@ -1,0 +1,50 @@
+<!DOCTYPE html>
+<html>
+<body>
+<script>
+// Helper for mock-MediaKeySession-backforwardcache-prune-crash.html. The previous page (with an open
+// MediaKeySession) is now in the BackForwardCache. Prune it -- which synchronously destroys the cached page and
+// tears down its still-open session -- and report the result here, since the pruned page is gone.
+//
+// This is a crash test: the success condition is "tearing down a back/forward-cached MediaKeySession page does not
+// crash". That holds whether the page was actually pruned or never entered the cache at all, so both outcomes
+// report the same PASS. Reporting PASS on non-entry keeps the test from flaking when the environment denies
+// caching: BackForwardCache::canCache() refuses entry while the process is under memory pressure (e.g. the WK2
+// Stress bot). A regression still aborts the process when the prune path is exercised, independent of this text.
+const PASS_MESSAGE = "PASS: pruning a back/forward-cached MediaKeySession page does not crash.";
+
+function finish(message) {
+    document.body.textContent = message;
+    if (window.testRunner)
+        testRunner.notifyDone();
+}
+
+function prune(retries = 0) {
+    // The previous page enters the cache as part of this navigation's commit; give it a few ticks if needed so we
+    // exercise the real prune path whenever caching is allowed.
+    if (internals.backForwardCacheSize() < 1) {
+        if (retries < 50) {
+            setTimeout(() => prune(retries + 1), 10);
+            return;
+        }
+        // Page never entered the cache (e.g. denied under memory pressure): nothing to prune, no crash.
+        finish(PASS_MESSAGE);
+        return;
+    }
+
+    // Synchronously destroys the cached page -> Document teardown -> MediaKeySession::stop(). Before the fix this
+    // crashed here; now it must return cleanly.
+    internals.clearBackForwardCache();
+    finish(PASS_MESSAGE);
+}
+
+window.addEventListener("load", () => {
+    if (!window.internals || !window.testRunner) {
+        finish("FAIL: this test requires window.internals and window.testRunner.");
+        return;
+    }
+    prune();
+});
+</script>
+</body>
+</html>

--- a/Source/WebCore/Modules/encryptedmedia/MediaKeySession.cpp
+++ b/Source/WebCore/Modules/encryptedmedia/MediaKeySession.cpp
@@ -861,8 +861,14 @@ void MediaKeySession::stop()
         if (!weakThis)
             return;
 
-        ALWAYS_LOG(logIdentifier, "::lambda, closed");
-        sessionClosed();
+        // closeSession() may invoke this callback synchronously (e.g. the Thunder backend), and stop() runs during
+        // document teardown while the event loop has already been marked ready-to-stop. Resolving the closed promise
+        // synchronously here would violate DeferredPromise's suspended-context invariant. Defer to the event loop,
+        // mirroring close(); the task is cleanly dropped if the event loop is already stopped.
+        queueTaskKeepingObjectAlive(*protectedThis, TaskSource::Networking, [logIdentifier](auto& session) {
+            ALWAYS_LOG_WITH_THIS(&session, logIdentifier, "::task, closed");
+            session.sessionClosed();
+        });
     });
 }
 

--- a/Source/WebCore/Modules/encryptedmedia/MediaKeySession.cpp
+++ b/Source/WebCore/Modules/encryptedmedia/MediaKeySession.cpp
@@ -800,6 +800,12 @@ void MediaKeySession::sessionClosed()
     // W3C Editor's Draft 09 November 2016
     ALWAYS_LOG(LOGIDENTIFIER);
 
+    // close(), stop(), and a CDM-reported close during update() each queue a task that lands here. They guard on
+    // m_closed before enqueuing, but it is only set when the task runs, so more than one task can already be queued.
+    // Update m_closed here to ensure the promise is only resolved once, and avoid an assertion in DOMPromiseProxy.
+    if (std::exchange(m_closed, true))
+        return;
+
     // 1. Let session be the associated MediaKeySession object.
     // 2. If session's session type is "persistent-usage-record", execute the following steps in parallel:
     if (m_sessionType == MediaKeySessionType::PersistentUsageRecord) {
@@ -813,9 +819,6 @@ void MediaKeySession::sessionClosed()
 
     // 4. Run the Update Expiration algorithm on the session, providing NaN.
     updateExpiration(std::numeric_limits<double>::quiet_NaN());
-
-    // Let's consider the session closed before any promise on the 'closed' attribute is resolved.
-    m_closed = true;
 
     // 5. Let promise be the closed attribute of the session.
     // 6. Resolve promise.

--- a/Source/WebCore/Modules/encryptedmedia/MediaKeySession.cpp
+++ b/Source/WebCore/Modules/encryptedmedia/MediaKeySession.cpp
@@ -822,6 +822,14 @@ void MediaKeySession::sessionClosed()
 
     // 5. Let promise be the closed attribute of the session.
     // 6. Resolve promise.
+    // Skip if the context is stopping (e.g. a back/forward-cached page being pruned); otherwise resolving the
+    // promise trips DeferredPromise's suspended-context assertion.
+    RefPtr context = scriptExecutionContext();
+    if (!context || context->activeDOMObjectsAreStopped()) {
+        ALWAYS_LOG(LOGIDENTIFIER, "Context is stopping; not resolving closed promise");
+        return;
+    }
+
     m_closedPromise->resolve();
 }
 
@@ -861,14 +869,10 @@ void MediaKeySession::stop()
         if (!weakThis)
             return;
 
-        // closeSession() may invoke this callback synchronously (e.g. the Thunder backend), and stop() runs during
-        // document teardown while the event loop has already been marked ready-to-stop. Resolving the closed promise
-        // synchronously here would violate DeferredPromise's suspended-context invariant. Defer to the event loop,
-        // mirroring close(); the task is cleanly dropped if the event loop is already stopped.
-        queueTaskKeepingObjectAlive(*protectedThis, TaskSource::Networking, [logIdentifier](auto& session) {
-            ALWAYS_LOG_WITH_THIS(&session, logIdentifier, "::task, closed");
-            session.sessionClosed();
-        });
+        // Run Session Closed synchronously to avoid the CDM session outliving the page and leaking into the next
+        // navigation.
+        ALWAYS_LOG(logIdentifier, "::lambda, closed");
+        weakThis->sessionClosed();
     });
 }
 


### PR DESCRIPTION
Backport of recent upstream EME crash fixes to wpe-2.46, corresponding to bugs https://bugs.webkit.org/show_bug.cgi?id=315842, https://bugs.webkit.org/show_bug.cgi?id=315849 and https://bugs.webkit.org/show_bug.cgi?id=316101<!--EWS-Status-Bubble-Start-->
https://github.com/WebPlatformForEmbedded/WPEWebKit/commit/6777219fba0ce1a11b669aba461e5df4484eaed9

| Build-Tests | Layout-Tests |
| ----------- | ------------ |
| | 
| | 
| [✅ 🛠 wpe-246-amd64-build](https://ews-wpe-rdk.igalia.com/#/builders/11/builds/306 "Built successfully") | [  ~~🧪 wpe-246-amd64-layout~~](https://ews-wpe-rdk.igalia.com/#/builders/9/builds/147 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [❌ 🛠 wpe-246-arm32-build](https://ews-wpe-rdk.igalia.com/#/builders/12/builds/306 "Failed to checkout and rebase branch from PR 1717") | [❌ 🧪 wpe-246-arm32-layout](https://ews-wpe-rdk.igalia.com/#/builders/12/builds/306 "Failed to checkout and rebase branch from PR 1717") 
<!--EWS-Status-Bubble-End-->