### PR TITLE
send stream-start event to donstream when app tries to append data after EOS

### DIFF
--- a/Source/WebCore/platform/graphics/gstreamer/mse/WebKitMediaSourceGStreamer.cpp
+++ b/Source/WebCore/platform/graphics/gstreamer/mse/WebKitMediaSourceGStreamer.cpp
@@ -634,12 +634,19 @@ static void webKitMediaSrcLoop(void* userData)
     } else if (GST_IS_EVENT(object.get())) {
         // EOS events and other enqueued events are also sent unlocked so they can react to flushes if necessary.
         GRefPtr<GstEvent> event = GRefPtr<GstEvent>(GST_EVENT(object.leakRef()));
+        bool isEOS = GST_EVENT_TYPE(event.get()) == GST_EVENT_EOS;
 
         streamingMembers.unlockEarly();
         GST_DEBUG_OBJECT(pad, "Pushing event downstream: %" GST_PTR_FORMAT, event.get());
         bool eventHandled = gst_pad_push_event(pad, GRefPtr<GstEvent>(event).leakRef());
         if (!eventHandled)
             GST_DEBUG_OBJECT(pad, "Pushed event was not handled: %" GST_PTR_FORMAT, event.get());
+
+        if (isEOS) {
+            DataMutexLocker streamingMembersAfterEOS { stream->streamingMembersDataMutex };
+            GST_INFO_OBJECT(pad, "EOS pushed, resetting wasStreamStartSent to allow re-sending STREAM_START.");
+            streamingMembersAfterEOS->wasStreamStartSent = false;
+        }
     } else
         ASSERT_NOT_REACHED();
 }


### PR DESCRIPTION
**Test Procedure:**

- Launch the MSNow app using
- { "url":"https://spinco.staging.smarttv.viewlift.com/viewlift-bitmovin-player/sample-project/index.html" }
- After app is launched, click on 'MS NOW Linear"
- Wait about 5-10mins for advertisement to play
- Green screen is appearing when advertisement starts.

Root Cause:
During MediaSource reuse across ad/content transitions, the pipeline remained in EOS state after EOS was pushed. Since STREAM_START was not re-sent, subsequent CAPS and buffer pushes failed, causing the MediaSource to close and resulting in a green screen during stream transitions.

Fix Done:
Modified webKitMediaSrcLoop() to reset wasStreamStartSent on EOS and re-send STREAM_START when the MediaSource is reused. This allows the pipeline to recover from EOS state and correctly process new segments during period and ad transitions.