### PR TITLE
[GStreamer] Use fixed watermarks for WebKitWebSource's internal queue

### DIFF
--- a/Source/WebCore/platform/graphics/gstreamer/WebKitWebSourceGStreamer.cpp
+++ b/Source/WebCore/platform/graphics/gstreamer/WebKitWebSourceGStreamer.cpp
@@ -45,16 +45,13 @@
 
 using namespace WebCore;
 
-// Never pause download of media resources smaller than 2MiB.
-#define SMALL_MEDIA_RESOURCE_MAX_SIZE 2 * 1024 * 1024
+// Keep at most 20MiB buffered. When this threshold is reached,
+// the download task is paused.
+#define HIGH_QUEUE_THRESHOLD 20 * 1024 * 1024
 
-// Keep at most 2% of the full, non-small, media resource buffered. When this
-// threshold is reached, the download task is paused.
-#define HIGH_QUEUE_FACTOR_THRESHOLD 0.02
-
-// Keep at least 20% of maximum queue size buffered. When this threshold is
-// reached, the download task resumes.
-#define LOW_QUEUE_FACTOR_THRESHOLD 0.2
+// Keep at least 2MiB buffered. When this threshold is reached,
+// the download task resumes.
+#define LOW_QUEUE_THRESHOLD 2 * 1024 * 1024
 
 class CachedResourceStreamingClient final : public PlatformMediaResourceClient {
     WTF_MAKE_FAST_ALLOCATED;
@@ -390,9 +387,9 @@ static void restartLoaderIfNeeded(WebKitWebSrc* src, DataMutexLocker<WebKitWebSr
     }
 
     GST_TRACE_OBJECT(src, "is download suspended %s, does have EOS %s, does have size %s, is seekable %s, size %" G_GUINT64_FORMAT
-        " (min %u)", boolForPrinting(members->isDownloadSuspended), boolForPrinting(members->doesHaveEOS), boolForPrinting(members->haveSize)
-        , boolForPrinting(members->isSeekable), members->size, SMALL_MEDIA_RESOURCE_MAX_SIZE);
-    if (members->doesHaveEOS || !members->haveSize || !members->isSeekable || members->size <= SMALL_MEDIA_RESOURCE_MAX_SIZE) {
+        , boolForPrinting(members->isDownloadSuspended), boolForPrinting(members->doesHaveEOS), boolForPrinting(members->haveSize)
+        , boolForPrinting(members->isSeekable), members->size);
+    if (members->doesHaveEOS || !members->isSeekable) {
         GST_TRACE_OBJECT(src, "download cannot be stopped/restarted");
         return;
     }
@@ -403,10 +400,9 @@ static void restartLoaderIfNeeded(WebKitWebSrc* src, DataMutexLocker<WebKitWebSr
     }
 
     size_t queueSize = gst_adapter_available(members->adapter.get());
-    GST_TRACE_OBJECT(src, "queue size %zu (min %1.0f)", queueSize
-        , members->size * HIGH_QUEUE_FACTOR_THRESHOLD * LOW_QUEUE_FACTOR_THRESHOLD);
+    GST_TRACE_OBJECT(src, "queue size %zu (min %d)", queueSize, LOW_QUEUE_THRESHOLD);
 
-    if (queueSize >= members->size * HIGH_QUEUE_FACTOR_THRESHOLD * LOW_QUEUE_FACTOR_THRESHOLD) {
+    if (queueSize >= LOW_QUEUE_THRESHOLD) {
         GST_TRACE_OBJECT(src, "queue size above low watermark, not restarting download");
         return;
     }
@@ -428,17 +424,17 @@ static void stopLoaderIfNeeded(WebKitWebSrc* src, DataMutexLocker<WebKitWebSrcPr
         return;
     }
 
-    GST_TRACE_OBJECT(src, "is download suspended %s, does have size %s, is seekable %s, size %" G_GUINT64_FORMAT " (min %u)"
-        , boolForPrinting(members->isDownloadSuspended), boolForPrinting(members->haveSize), boolForPrinting(members->isSeekable), members->size
-        , SMALL_MEDIA_RESOURCE_MAX_SIZE);
-    if (!members->isSeekable || members->size <= SMALL_MEDIA_RESOURCE_MAX_SIZE) {
+    GST_TRACE_OBJECT(src, "is download suspended %s, does have size %s, is seekable %s, size %" G_GUINT64_FORMAT
+        , boolForPrinting(members->isDownloadSuspended), boolForPrinting(members->haveSize), boolForPrinting(members->isSeekable), members->size);
+
+    if (!members->isSeekable) {
         GST_TRACE_OBJECT(src, "download cannot be stopped/restarted");
         return;
     }
 
     size_t queueSize = gst_adapter_available(members->adapter.get());
-    GST_TRACE_OBJECT(src, "queue size %zu (max %1.0f)", queueSize, members->size * HIGH_QUEUE_FACTOR_THRESHOLD);
-    if (queueSize <= members->size * HIGH_QUEUE_FACTOR_THRESHOLD) {
+    GST_TRACE_OBJECT(src, "queue size %zu (max %d)", queueSize, HIGH_QUEUE_THRESHOLD);
+    if (queueSize <= HIGH_QUEUE_THRESHOLD) {
         GST_TRACE_OBJECT(src, "queue size under high watermark, not stopping download");
         return;
     }


### PR DESCRIPTION
https://bugs.webkit.org/show_bug.cgi?id=322499

Reviewed by Philippe Normand.

Currently we use watermarks proportional to the total size of the resource, which can result in excessively large or small watermarks, and requires a special case for small files (arguably one would be needed for large files too).

Setting fixed values for watermarks will be simpler and more consistent.

* Source/WebCore/platform/graphics/gstreamer/WebKitWebSourceGStreamer.cpp: (restartLoaderIfNeeded):
(stopLoaderIfNeeded):

Canonical link: https://commits.webkit.org/319853@main
<!--EWS-Status-Bubble-Start-->
https://github.com/WebPlatformForEmbedded/WPEWebKit/commit/582b6597be63504148d7a6356da6ddc9d0002532

| Build-Tests | Layout-Tests |
| ----------- | ------------ |
| [✅ 🛠 wpe-238-amd64-build](https://ews-wpe-rdk.igalia.com/#/builders/1/builds/298 "Built successfully") | [✅ 🧪 wpe-238-amd64-layout](https://ews-wpe-rdk.igalia.com/#/builders/5/builds/104 "Passed tests") 
| [✅ 🛠 wpe-238-arm32-build](https://ews-wpe-rdk.igalia.com/#/builders/8/builds/297 "Built successfully") | [✅ 🧪 wpe-238-arm32-layout](https://ews-wpe-rdk.igalia.com/#/builders/6/builds/113 "Passed tests") 
| | 
| | 
<!--EWS-Status-Bubble-End-->