### PR TITLE
Add KEY_TV key mapping for libwpe impl

### DIFF
--- a/Source/WebCore/platform/PlatformKeyboardEvent.h
+++ b/Source/WebCore/platform/PlatformKeyboardEvent.h
@@ -138,7 +138,7 @@ namespace WebCore {
 #endif
 
 #if USE(LIBWPE)
-        static String keyValueForWPEKeyCode(unsigned);
+        static String keyValueForWPEKeyCode(unsigned, unsigned);
         static String keyCodeForHardwareKeyCode(unsigned);
         static String keyIdentifierForWPEKeyCode(unsigned);
         static int windowsKeyCodeForWPEKeyCode(unsigned);

--- a/Source/WebCore/platform/libwpe/PlatformKeyboardEventLibWPE.cpp
+++ b/Source/WebCore/platform/libwpe/PlatformKeyboardEventLibWPE.cpp
@@ -40,8 +40,11 @@ namespace WebCore {
 // more like what Firefox does, and generate these switch statements
 // at build time.
 // https://developer.mozilla.org/en-US/docs/Web/API/KeyboardEvent/key/Key_Values
-String PlatformKeyboardEvent::keyValueForWPEKeyCode(unsigned keyCode)
+String PlatformKeyboardEvent::keyValueForWPEKeyCode(unsigned keyCode, unsigned hwKeyCode)
 {
+    if (keyCode == 0 && hwKeyCode == 0x181) // KEY_TV
+        return "TV"_s;
+
     switch (keyCode) {
     // Modifier keys.
     case WPE_KEY_Alt_L:

--- a/Source/WebKit/Shared/libwpe/WebEventFactory.cpp
+++ b/Source/WebKit/Shared/libwpe/WebEventFactory.cpp
@@ -117,7 +117,7 @@ WebKeyboardEvent WebEventFactory::createWebKeyboardEvent(struct wpe_input_keyboa
 {
     return WebKeyboardEvent({ event->pressed ? WebEventType::KeyDown : WebEventType::KeyUp, modifiersForKeyboardEvent(event), wallTimeForEventTime(event->time) },
         text.isNull() ? WebCore::PlatformKeyboardEvent::singleCharacterString(event->key_code) : text,
-        WebCore::PlatformKeyboardEvent::keyValueForWPEKeyCode(event->key_code),
+        WebCore::PlatformKeyboardEvent::keyValueForWPEKeyCode(event->key_code, event->hardware_key_code),
         WebCore::PlatformKeyboardEvent::keyCodeForHardwareKeyCode(event->hardware_key_code),
         WebCore::PlatformKeyboardEvent::keyIdentifierForWPEKeyCode(event->key_code),
         WebCore::PlatformKeyboardEvent::windowsKeyCodeForWPEKeyCode(event->key_code),


### PR DESCRIPTION
This is needed to handle LiveTV button on TV remote. Use "TV" key value as defined in W3C
https://www.w3.org/TR/uievents-key/#keys-tv

Leave code value Undefined since there is no well defined value for code prop.<!--EWS-Status-Bubble-Start-->
https://github.com/WebPlatformForEmbedded/WPEWebKit/commit/fe3aedcf221715f0963ed0da4b79c6346d197c3e

| Build-Tests | Layout-Tests |
| ----------- | ------------ |
| | 
| | 
| [✅ 🛠 wpe-246-amd64-build](https://ews-wpe-rdk.igalia.com/#/builders/11/builds/316 "Built successfully") | [✅ 🧪 wpe-246-amd64-layout](https://ews-wpe-rdk.igalia.com/#/builders/9/builds/153 "Passed tests") 
| [✅ 🛠 wpe-246-arm32-build](https://ews-wpe-rdk.igalia.com/#/builders/12/builds/317 "Built successfully") | [✅ 🧪 wpe-246-arm32-layout](https://ews-wpe-rdk.igalia.com/#/builders/10/builds/158 "Passed tests") 
<!--EWS-Status-Bubble-End-->