### PR TITLE
Continuing user initiated navigation on page-script-initiated reload

### DIFF
--- a/Source/WebCore/loader/FrameLoader.cpp
+++ b/Source/WebCore/loader/FrameLoader.cpp
@@ -1405,7 +1405,24 @@ void FrameLoader::loadURL(FrameLoadRequest&& frameLoadRequest, const String& ref
 
     bool sameURL = shouldTreatURLAsSameAsCurrent(&frameLoadRequest.requesterSecurityOrigin(), newURL);
     const String& httpMethod = request.httpMethod();
-    
+
+    static bool keepNavigationOnLocationReload = false;
+    static bool keepNavigationOnLocationReloadInitialized = false;
+    if (!keepNavigationOnLocationReloadInitialized) {
+        keepNavigationOnLocationReload = !!getenv("WPE_KEEP_NAVIGATION_ON_LOCATION_RELOAD");
+        keepNavigationOnLocationReloadInitialized = true;
+    }
+    // A page-script-initiated reload (e.g. window.location.reload() via a timer) racing
+    // an already-in-flight client/user navigation to a different URL (e.g. a native
+    // webkit_web_view_load_uri() call). Stop a page-script-initiated reload here.
+    if (keepNavigationOnLocationReload && isReload(newLoadType) && !frameLoadRequest.isRequestFromClientOrUserInput()) {
+        DocumentLoader* ongoingLoader = m_policyDocumentLoader ? m_policyDocumentLoader.get() : m_provisionalDocumentLoader.get();
+        if (ongoingLoader && ongoingLoader->isRequestFromClientOrUserInput() && ongoingLoader->request().url() != newURL) {
+            FRAMELOADER_RELEASE_LOG(ResourceLoading, "loadURL: navigation to: %s will be continued after location reload to url: %s", ongoingLoader->request().url().string().utf8().data(), newURL.string().utf8().data());
+            return;
+        }
+    }
+
     // Make sure to do scroll to fragment processing even if the URL is
     // exactly the same so pages with '#' links and DHTML side effects
     // work properly.


### PR DESCRIPTION
<!--EWS-Status-Bubble-Start-->
https://github.com/WebPlatformForEmbedded/WPEWebKit/commit/ce3dcc0051844b6ef80ba07a188cbf357bb705da

| Build-Tests | Layout-Tests |
| ----------- | ------------ |
| [✅ 🛠 wpe-238-amd64-build](https://ews-wpe-rdk.igalia.com/#/builders/1/builds/302 "Built successfully") | [✅ 🧪 wpe-238-amd64-layout](https://ews-wpe-rdk.igalia.com/#/builders/5/builds/106 "Passed tests") 
| [✅ 🛠 wpe-238-arm32-build](https://ews-wpe-rdk.igalia.com/#/builders/8/builds/301 "Built successfully") | [✅ 🧪 wpe-238-arm32-layout](https://ews-wpe-rdk.igalia.com/#/builders/6/builds/115 "Passed tests") 
| | 
| | 
<!--EWS-Status-Bubble-End-->